### PR TITLE
Remove unused LyricsProtocol and use Lyrics directly

### DIFF
--- a/src/barscan/analyzer/__init__.py
+++ b/src/barscan/analyzer/__init__.py
@@ -8,7 +8,6 @@ from barscan.analyzer.filters import (
     get_stop_words,
 )
 from barscan.analyzer.frequency import (
-    LyricsProtocol,
     aggregate_results,
     analyze_lyrics,
     analyze_text,
@@ -50,7 +49,6 @@ __all__ = [
     "apply_filters",
     "get_stop_words",
     # Frequency
-    "LyricsProtocol",
     "analyze_text",
     "analyze_lyrics",
     "aggregate_results",

--- a/src/barscan/analyzer/frequency.py
+++ b/src/barscan/analyzer/frequency.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import Counter
 from datetime import UTC, datetime
-from typing import Protocol
+from typing import TYPE_CHECKING
 
 from barscan.analyzer.filters import apply_filters
 from barscan.analyzer.models import (
@@ -16,24 +16,8 @@ from barscan.analyzer.models import (
 from barscan.analyzer.processor import preprocess
 from barscan.exceptions import EmptyLyricsError
 
-
-class LyricsProtocol(Protocol):
-    """Protocol for lyrics objects compatible with analyze_lyrics."""
-
-    @property
-    def song_id(self) -> int: ...
-
-    @property
-    def song_title(self) -> str: ...
-
-    @property
-    def artist_name(self) -> str: ...
-
-    @property
-    def text(self) -> str: ...
-
-    @property
-    def is_empty(self) -> bool: ...
+if TYPE_CHECKING:
+    from barscan.genius.models import Lyrics
 
 
 def count_frequencies(tokens: list[str]) -> Counter[str]:
@@ -136,7 +120,7 @@ def analyze_text(
 
 
 def analyze_lyrics(
-    lyrics: LyricsProtocol,
+    lyrics: Lyrics,
     config: AnalysisConfig | None = None,
 ) -> AnalysisResult:
     """Perform word frequency analysis on a Lyrics object.
@@ -144,7 +128,7 @@ def analyze_lyrics(
     Convenience wrapper around analyze_text that extracts fields from Lyrics model.
 
     Args:
-        lyrics: Lyrics object implementing LyricsProtocol.
+        lyrics: Lyrics object from genius module.
         config: Analysis configuration (uses default if None).
 
     Returns:
@@ -157,7 +141,7 @@ def analyze_lyrics(
         raise EmptyLyricsError(f"No lyrics available for song '{lyrics.song_title}'")
 
     return analyze_text(
-        text=lyrics.text,
+        text=lyrics.lyrics_text,
         song_id=lyrics.song_id,
         song_title=lyrics.song_title,
         artist_name=lyrics.artist_name,


### PR DESCRIPTION
## Summary
- Remove `LyricsProtocol` class that was a workaround for missing `genius.models`
- Import `Lyrics` from `genius.models` using `TYPE_CHECKING`
- Fix `analyze_lyrics` to use `lyrics.lyrics_text` instead of `lyrics.text`

## Background
Commit `4df109e` introduced `LyricsProtocol` because PR #14 was branched from an older main that didn't have `genius/models.py` (added in PR #10). Now that both PRs are merged, this workaround is no longer needed and actually had an incompatibility (`text` vs `lyrics_text`).

## Test plan
- [x] All 133 tests pass
- [x] mypy type checking passes
- [x] ruff linting passes