### PR TITLE
Add WordGrain format output support

### DIFF
--- a/src/barscan/output/__init__.py
+++ b/src/barscan/output/__init__.py
@@ -1,1 +1,23 @@
 """Output formatting module."""
+
+from barscan.output.wordgrain import (
+    WORDGRAIN_SCHEMA_URL,
+    WordGrainDocument,
+    WordGrainGrain,
+    WordGrainMeta,
+    export_wordgrain,
+    generate_filename,
+    slugify,
+    to_wordgrain,
+)
+
+__all__ = [
+    "WORDGRAIN_SCHEMA_URL",
+    "WordGrainDocument",
+    "WordGrainGrain",
+    "WordGrainMeta",
+    "export_wordgrain",
+    "generate_filename",
+    "slugify",
+    "to_wordgrain",
+]

--- a/src/barscan/output/wordgrain.py
+++ b/src/barscan/output/wordgrain.py
@@ -1,0 +1,190 @@
+"""WordGrain format output for BarScan.
+
+This module provides Pydantic models and functions to export analysis results
+in the WordGrain JSON format (.wg.json), a standardized schema for vocabulary
+analysis data.
+
+Reference: https://mumbl.dev/schemas/wordgrain/v0.1.0
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from datetime import datetime
+from importlib.metadata import version
+
+from pydantic import BaseModel, Field
+
+from barscan.analyzer.models import AggregateAnalysisResult
+
+WORDGRAIN_SCHEMA_URL = "https://mumbl.dev/schemas/wordgrain/v0.1.0"
+
+
+class WordGrainGrain(BaseModel, frozen=True):
+    """A single word entry in WordGrain format.
+
+    Attributes:
+        word: The vocabulary word.
+        frequency: Raw occurrence count.
+        frequency_normalized: Occurrences per 10,000 words.
+    """
+
+    word: str = Field(..., min_length=1, description="The vocabulary word")
+    frequency: int = Field(..., ge=0, description="Raw occurrence count")
+    frequency_normalized: float = Field(..., ge=0.0, description="Occurrences per 10,000 words")
+
+
+class WordGrainMeta(BaseModel, frozen=True):
+    """Metadata section of a WordGrain document.
+
+    Attributes:
+        source: Data source identifier.
+        artist: Primary artist name.
+        generated_at: ISO 8601 datetime of generation.
+        corpus_size: Number of tracks analyzed.
+        total_words: Total word count in corpus.
+        generator: Tool identifier with version.
+        language: ISO 639-1 language code.
+    """
+
+    source: str = Field(default="genius", description="Data source identifier")
+    artist: str = Field(..., description="Primary artist name")
+    generated_at: datetime = Field(..., description="ISO 8601 datetime of generation")
+    corpus_size: int = Field(..., ge=0, description="Number of tracks analyzed")
+    total_words: int = Field(..., ge=0, description="Total word count in corpus")
+    generator: str = Field(..., description="Tool identifier with version")
+    language: str = Field(default="en", description="ISO 639-1 language code")
+
+
+class WordGrainDocument(BaseModel, frozen=True):
+    """Root WordGrain document structure.
+
+    Attributes:
+        schema_: JSON Schema URL (serialized as $schema).
+        meta: Document metadata.
+        grains: List of word entries.
+    """
+
+    schema_: str = Field(
+        default=WORDGRAIN_SCHEMA_URL,
+        alias="$schema",
+        description="JSON Schema URL",
+    )
+    meta: WordGrainMeta = Field(..., description="Document metadata")
+    grains: tuple[WordGrainGrain, ...] = Field(
+        default_factory=tuple, description="List of word entries"
+    )
+
+
+def slugify(text: str) -> str:
+    """Convert text to URL-safe slug.
+
+    Args:
+        text: Input text to slugify.
+
+    Returns:
+        Lowercase ASCII slug with hyphens.
+    """
+    # Normalize unicode characters
+    text = unicodedata.normalize("NFKD", text)
+    # Encode to ASCII, ignoring non-ASCII chars
+    text = text.encode("ascii", "ignore").decode("ascii")
+    # Convert to lowercase
+    text = text.lower()
+    # Replace spaces and underscores with hyphens
+    text = re.sub(r"[\s_]+", "-", text)
+    # Remove non-alphanumeric characters except hyphens
+    text = re.sub(r"[^a-z0-9-]", "", text)
+    # Remove consecutive hyphens
+    text = re.sub(r"-+", "-", text)
+    # Strip leading/trailing hyphens
+    text = text.strip("-")
+    return text
+
+
+def generate_filename(artist_name: str) -> str:
+    """Generate WordGrain filename from artist name.
+
+    Args:
+        artist_name: Artist name to convert.
+
+    Returns:
+        Filename in format: {artist-slug}.wg.json
+    """
+    slug = slugify(artist_name)
+    return f"{slug}.wg.json"
+
+
+def _get_generator_string() -> str:
+    """Get the generator string with version."""
+    try:
+        ver = version("barscan")
+    except Exception:
+        ver = "0.1.0"
+    return f"barscan/{ver}"
+
+
+def to_wordgrain(
+    aggregate: AggregateAnalysisResult,
+    language: str = "en",
+) -> WordGrainDocument:
+    """Convert analysis results to WordGrain format.
+
+    Args:
+        aggregate: Aggregated analysis results.
+        language: ISO 639-1 language code.
+
+    Returns:
+        WordGrainDocument ready for export.
+    """
+    # Convert frequencies to grains
+    grains: list[WordGrainGrain] = []
+    for freq in aggregate.frequencies:
+        # Calculate normalized frequency (per 10,000 words)
+        if aggregate.total_words > 0:
+            normalized = round((freq.count / aggregate.total_words) * 10000, 2)
+        else:
+            normalized = 0.0
+        grains.append(
+            WordGrainGrain(
+                word=freq.word,
+                frequency=freq.count,
+                frequency_normalized=normalized,
+            )
+        )
+
+    # Build metadata
+    meta = WordGrainMeta(
+        source="genius",
+        artist=aggregate.artist_name,
+        generated_at=aggregate.analyzed_at,
+        corpus_size=aggregate.songs_analyzed,
+        total_words=aggregate.total_words,
+        generator=_get_generator_string(),
+        language=language,
+    )
+
+    return WordGrainDocument(
+        meta=meta,
+        grains=tuple(grains),
+    )
+
+
+def export_wordgrain(
+    document: WordGrainDocument,
+    indent: int = 2,
+) -> str:
+    """Export WordGrain document to JSON string.
+
+    Args:
+        document: WordGrain document to export.
+        indent: JSON indentation level.
+
+    Returns:
+        JSON string with proper formatting.
+    """
+    return document.model_dump_json(
+        by_alias=True,
+        indent=indent,
+    )

--- a/tests/test_output/__init__.py
+++ b/tests/test_output/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for output module."""

--- a/tests/test_output/test_wordgrain.py
+++ b/tests/test_output/test_wordgrain.py
@@ -1,0 +1,354 @@
+"""Tests for WordGrain output module."""
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from barscan.analyzer.models import AggregateAnalysisResult, WordFrequency
+from barscan.output.wordgrain import (
+    WORDGRAIN_SCHEMA_URL,
+    WordGrainDocument,
+    WordGrainGrain,
+    WordGrainMeta,
+    export_wordgrain,
+    generate_filename,
+    slugify,
+    to_wordgrain,
+)
+
+
+class TestWordGrainGrain:
+    """Tests for WordGrainGrain model."""
+
+    def test_create_grain(self) -> None:
+        """Test creating a WordGrainGrain instance."""
+        grain = WordGrainGrain(word="love", frequency=50, frequency_normalized=100.0)
+        assert grain.word == "love"
+        assert grain.frequency == 50
+        assert grain.frequency_normalized == 100.0
+
+    def test_grain_is_frozen(self) -> None:
+        """Test that WordGrainGrain is immutable."""
+        grain = WordGrainGrain(word="love", frequency=50, frequency_normalized=100.0)
+        with pytest.raises(ValidationError):
+            grain.word = "heart"  # type: ignore[misc]
+
+    def test_grain_validation_empty_word(self) -> None:
+        """Test that empty word is rejected."""
+        with pytest.raises(ValidationError):
+            WordGrainGrain(word="", frequency=50, frequency_normalized=100.0)
+
+    def test_grain_validation_negative_frequency(self) -> None:
+        """Test that negative frequency is rejected."""
+        with pytest.raises(ValidationError):
+            WordGrainGrain(word="love", frequency=-1, frequency_normalized=100.0)
+
+    def test_grain_validation_negative_normalized(self) -> None:
+        """Test that negative frequency_normalized is rejected."""
+        with pytest.raises(ValidationError):
+            WordGrainGrain(word="love", frequency=50, frequency_normalized=-1.0)
+
+
+class TestWordGrainMeta:
+    """Tests for WordGrainMeta model."""
+
+    def test_create_meta_with_defaults(self) -> None:
+        """Test creating meta with default values."""
+        now = datetime.now(UTC)
+        meta = WordGrainMeta(
+            artist="Kendrick Lamar",
+            generated_at=now,
+            corpus_size=10,
+            total_words=5000,
+            generator="barscan/0.1.0",
+        )
+        assert meta.source == "genius"
+        assert meta.artist == "Kendrick Lamar"
+        assert meta.language == "en"
+        assert meta.corpus_size == 10
+        assert meta.total_words == 5000
+
+    def test_create_meta_custom(self) -> None:
+        """Test creating meta with custom values."""
+        now = datetime.now(UTC)
+        meta = WordGrainMeta(
+            source="custom",
+            artist="J. Cole",
+            generated_at=now,
+            corpus_size=5,
+            total_words=2500,
+            generator="barscan/1.0.0",
+            language="es",
+        )
+        assert meta.source == "custom"
+        assert meta.language == "es"
+
+    def test_meta_is_frozen(self) -> None:
+        """Test that WordGrainMeta is immutable."""
+        meta = WordGrainMeta(
+            artist="Test",
+            generated_at=datetime.now(UTC),
+            corpus_size=1,
+            total_words=100,
+            generator="test/0.1.0",
+        )
+        with pytest.raises(ValidationError):
+            meta.artist = "New Artist"  # type: ignore[misc]
+
+
+class TestWordGrainDocument:
+    """Tests for WordGrainDocument model."""
+
+    def test_create_document(self) -> None:
+        """Test creating a WordGrainDocument."""
+        now = datetime.now(UTC)
+        meta = WordGrainMeta(
+            artist="Test Artist",
+            generated_at=now,
+            corpus_size=5,
+            total_words=1000,
+            generator="barscan/0.1.0",
+        )
+        grains = (
+            WordGrainGrain(word="love", frequency=50, frequency_normalized=500.0),
+            WordGrainGrain(word="heart", frequency=30, frequency_normalized=300.0),
+        )
+        doc = WordGrainDocument(meta=meta, grains=grains)
+        assert doc.schema_ == WORDGRAIN_SCHEMA_URL
+        assert doc.meta == meta
+        assert len(doc.grains) == 2
+
+    def test_document_default_schema(self) -> None:
+        """Test default schema URL."""
+        doc = WordGrainDocument(
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        assert doc.schema_ == "https://mumbl.dev/schemas/wordgrain/v0.1.0"
+
+    def test_schema_field_alias(self) -> None:
+        """Test that $schema field is serialized correctly."""
+        doc = WordGrainDocument(
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        json_str = doc.model_dump_json(by_alias=True)
+        data = json.loads(json_str)
+        assert "$schema" in data
+        assert "schema_" not in data
+        assert data["$schema"] == WORDGRAIN_SCHEMA_URL
+
+
+class TestSlugify:
+    """Tests for slugify function."""
+
+    def test_slugify_simple(self) -> None:
+        """Test slugifying a simple name."""
+        assert slugify("Kendrick Lamar") == "kendrick-lamar"
+
+    def test_slugify_with_special_chars(self) -> None:
+        """Test slugifying a name with special characters."""
+        assert slugify("J. Cole") == "j-cole"
+
+    def test_slugify_with_unicode(self) -> None:
+        """Test slugifying a name with unicode characters."""
+        assert slugify("Björk") == "bjork"
+
+    def test_slugify_multiple_spaces(self) -> None:
+        """Test slugifying a name with multiple spaces."""
+        assert slugify("The   Weeknd") == "the-weeknd"
+
+    def test_slugify_empty(self) -> None:
+        """Test slugifying an empty string."""
+        assert slugify("") == ""
+
+    def test_slugify_special_only(self) -> None:
+        """Test slugifying only special characters."""
+        assert slugify("!@#$%") == ""
+
+
+class TestGenerateFilename:
+    """Tests for generate_filename function."""
+
+    def test_generate_filename_simple(self) -> None:
+        """Test generating filename from simple name."""
+        assert generate_filename("Kendrick Lamar") == "kendrick-lamar.wg.json"
+
+    def test_generate_filename_special_chars(self) -> None:
+        """Test generating filename with special characters."""
+        assert generate_filename("Tyler, the Creator") == "tyler-the-creator.wg.json"
+
+
+class TestToWordgrain:
+    """Tests for to_wordgrain converter."""
+
+    @pytest.fixture
+    def sample_aggregate(self) -> AggregateAnalysisResult:
+        """Create a sample AggregateAnalysisResult for testing."""
+        frequencies = (
+            WordFrequency(word="love", count=50, percentage=1.0),
+            WordFrequency(word="heart", count=30, percentage=0.6),
+            WordFrequency(word="soul", count=20, percentage=0.4),
+        )
+        return AggregateAnalysisResult(
+            artist_name="Test Artist",
+            songs_analyzed=5,
+            total_words=5000,
+            unique_words=500,
+            frequencies=frequencies,
+            song_results=(),
+            analyzed_at=datetime(2026, 2, 9, 12, 0, 0, tzinfo=UTC),
+        )
+
+    def test_converts_frequencies(self, sample_aggregate: AggregateAnalysisResult) -> None:
+        """Test that frequencies are converted correctly."""
+        doc = to_wordgrain(sample_aggregate)
+        assert len(doc.grains) == 3
+        assert doc.grains[0].word == "love"
+        assert doc.grains[0].frequency == 50
+        assert doc.grains[1].word == "heart"
+        assert doc.grains[1].frequency == 30
+
+    def test_frequency_normalization(self, sample_aggregate: AggregateAnalysisResult) -> None:
+        """Test that frequency_normalized is calculated correctly (per 10,000 words)."""
+        doc = to_wordgrain(sample_aggregate)
+        # 50 / 5000 * 10000 = 100.0
+        assert doc.grains[0].frequency_normalized == 100.0
+        # 30 / 5000 * 10000 = 60.0
+        assert doc.grains[1].frequency_normalized == 60.0
+        # 20 / 5000 * 10000 = 40.0
+        assert doc.grains[2].frequency_normalized == 40.0
+
+    def test_meta_mapping(self, sample_aggregate: AggregateAnalysisResult) -> None:
+        """Test that meta fields are mapped correctly."""
+        doc = to_wordgrain(sample_aggregate)
+        assert doc.meta.artist == "Test Artist"
+        assert doc.meta.corpus_size == 5
+        assert doc.meta.total_words == 5000
+        assert doc.meta.generated_at == datetime(2026, 2, 9, 12, 0, 0, tzinfo=UTC)
+        assert doc.meta.source == "genius"
+
+    def test_custom_language(self, sample_aggregate: AggregateAnalysisResult) -> None:
+        """Test custom language setting."""
+        doc = to_wordgrain(sample_aggregate, language="es")
+        assert doc.meta.language == "es"
+
+    def test_zero_total_words(self) -> None:
+        """Test handling of zero total_words."""
+        aggregate = AggregateAnalysisResult(
+            artist_name="Empty Artist",
+            songs_analyzed=0,
+            total_words=0,
+            unique_words=0,
+            frequencies=(),
+            song_results=(),
+            analyzed_at=datetime.now(UTC),
+        )
+        doc = to_wordgrain(aggregate)
+        assert len(doc.grains) == 0
+
+
+class TestExportWordgrain:
+    """Tests for export_wordgrain function."""
+
+    def test_export_valid_json(self) -> None:
+        """Test that export produces valid JSON."""
+        doc = WordGrainDocument(
+            meta=WordGrainMeta(
+                artist="Test Artist",
+                generated_at=datetime(2026, 2, 9, 12, 0, 0, tzinfo=UTC),
+                corpus_size=5,
+                total_words=1000,
+                generator="barscan/0.1.0",
+            ),
+            grains=(WordGrainGrain(word="love", frequency=50, frequency_normalized=500.0),),
+        )
+        json_str = export_wordgrain(doc)
+        data = json.loads(json_str)
+        assert isinstance(data, dict)
+
+    def test_export_schema_field(self) -> None:
+        """Test that $schema appears in output."""
+        doc = WordGrainDocument(
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        json_str = export_wordgrain(doc)
+        data = json.loads(json_str)
+        assert "$schema" in data
+        assert data["$schema"] == WORDGRAIN_SCHEMA_URL
+
+    def test_export_format_indentation(self) -> None:
+        """Test JSON formatting with indentation."""
+        doc = WordGrainDocument(
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        json_str = export_wordgrain(doc, indent=2)
+        assert "\n" in json_str
+        assert "  " in json_str
+
+    def test_export_no_indentation(self) -> None:
+        """Test JSON formatting without indentation."""
+        doc = WordGrainDocument(
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        json_str = export_wordgrain(doc, indent=0)
+        lines = json_str.strip().split("\n")
+        assert len(lines) > 1
+
+    def test_export_grains_structure(self) -> None:
+        """Test that grains are exported with correct structure."""
+        doc = WordGrainDocument(
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(
+                WordGrainGrain(word="love", frequency=50, frequency_normalized=5000.0),
+                WordGrainGrain(word="heart", frequency=30, frequency_normalized=3000.0),
+            ),
+        )
+        json_str = export_wordgrain(doc)
+        data = json.loads(json_str)
+        assert "grains" in data
+        assert len(data["grains"]) == 2
+        assert data["grains"][0]["word"] == "love"
+        assert data["grains"][0]["frequency"] == 50
+        assert data["grains"][0]["frequency_normalized"] == 5000.0


### PR DESCRIPTION
## Summary

- Add WordGrain JSON schema (.wg.json) export format for analysis results
- Implement Pydantic models: `WordGrainDocument`, `WordGrainMeta`, `WordGrainGrain`
- Add `to_wordgrain()` converter and `export_wordgrain()` function
- Add `slugify()` and `generate_filename()` utilities
- Integrate WORDGRAIN format option in CLI (`-f wordgrain`)

## Test plan

- [x] All 162 tests pass
- [x] Lint and type checks pass
- [ ] Manual test: `barscan analyze "Artist Name" -f wordgrain`
- [ ] Verify JSON output matches WordGrain schema

## Usage

```bash
# Output to stdout
barscan analyze "Kendrick Lamar" -f wordgrain

# Output to file
barscan analyze "Kendrick Lamar" -f wordgrain -o kendrick-lamar.wg.json
```

Closes #17
Closes #5