### PR TITLE
Add release workflow for GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint
+        run: ruff check src/
+
+      - name: Format check
+        run: ruff format --check src/
+
+      - name: Type check
+        run: mypy src/barscan/ --ignore-missing-imports
+
+      - name: Test
+        run: pytest
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --title "Release ${{ github.ref_name }}" \
+            --generate-notes \
+            dist/*


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow that triggers on tag push (`v*`)
- Run pre-release verification (lint, format, type check, tests) on Python 3.11 and 3.12
- Build wheel and sdist packages using `python -m build`
- Upload artifacts to GitHub Releases using `gh release create`

## Test plan
- [x] Verified local build works with `python -m build`
- [x] Confirmed wheel (`.whl`) and sdist (`.tar.gz`) are created in `dist/`
- [x] All 162 tests pass locally
- [x] Lint checks pass
- [ ] Test release workflow by pushing a tag (e.g., `v0.1.0`) after merge

Closes #8