### PR TITLE
Add enhanced NLP fields to WordGrain output

### DIFF
--- a/src/barscan/analyzer/__init__.py
+++ b/src/barscan/analyzer/__init__.py
@@ -11,22 +11,29 @@ from barscan.analyzer.frequency import (
     aggregate_results,
     analyze_lyrics,
     analyze_text,
+    collect_tokens_with_positions,
     count_frequencies,
     create_word_frequencies,
+    get_word_counts_per_song,
 )
 from barscan.analyzer.models import (
     AggregateAnalysisResult,
     AnalysisConfig,
     AnalysisResult,
+    ContextsMode,
+    TokenWithPosition,
+    WordContext,
     WordFrequency,
 )
 from barscan.analyzer.processor import (
     clean_lyrics,
+    clean_lyrics_preserve_lines,
     ensure_nltk_resources,
     lemmatize,
     normalize_text,
     preprocess,
     tokenize,
+    tokenize_with_positions,
 )
 
 __all__ = [
@@ -35,10 +42,15 @@ __all__ = [
     "AnalysisResult",
     "AggregateAnalysisResult",
     "WordFrequency",
+    "ContextsMode",
+    "TokenWithPosition",
+    "WordContext",
     # Processor
     "clean_lyrics",
+    "clean_lyrics_preserve_lines",
     "normalize_text",
     "tokenize",
+    "tokenize_with_positions",
     "lemmatize",
     "preprocess",
     "ensure_nltk_resources",
@@ -54,4 +66,6 @@ __all__ = [
     "aggregate_results",
     "count_frequencies",
     "create_word_frequencies",
+    "get_word_counts_per_song",
+    "collect_tokens_with_positions",
 ]

--- a/src/barscan/analyzer/context.py
+++ b/src/barscan/analyzer/context.py
@@ -1,0 +1,172 @@
+"""Context extraction for word occurrences in lyrics."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from barscan.analyzer.models import ContextsMode, TokenWithPosition, WordContext
+
+if TYPE_CHECKING:
+    pass
+
+
+def extract_short_context(
+    line: str,
+    word: str,
+    window_size: int = 2,
+) -> str:
+    """Extract a short context window around a word in a line.
+
+    Creates a snippet like "...my love for you..." with the target word
+    surrounded by window_size words on each side.
+
+    Args:
+        line: The full line of lyrics.
+        word: The target word to find context for.
+        window_size: Number of words to include on each side.
+
+    Returns:
+        Context snippet with ellipsis markers.
+    """
+    # Split line into words (preserving punctuation attached to words)
+    words = line.split()
+    word_lower = word.lower()
+
+    # Find the word position (case-insensitive)
+    word_index = -1
+    for i, w in enumerate(words):
+        # Strip punctuation for comparison
+        clean_w = re.sub(r"[^\w']", "", w.lower())
+        if clean_w == word_lower:
+            word_index = i
+            break
+
+    if word_index == -1:
+        # Word not found, return truncated line
+        if len(words) <= window_size * 2 + 1:
+            return line.strip()
+        return "..." + " ".join(words[: window_size * 2 + 1]) + "..."
+
+    # Extract window
+    start = max(0, word_index - window_size)
+    end = min(len(words), word_index + window_size + 1)
+    context_words = words[start:end]
+
+    # Add ellipsis markers
+    prefix = "..." if start > 0 else ""
+    suffix = "..." if end < len(words) else ""
+
+    return f"{prefix}{' '.join(context_words)}{suffix}"
+
+
+def extract_full_context(
+    line: str,
+    song_title: str,
+    album: str | None = None,
+    year: int | None = None,
+) -> WordContext:
+    """Extract full context with metadata.
+
+    Args:
+        line: The full line of lyrics.
+        song_title: The song title.
+        album: Optional album name.
+        year: Optional release year.
+
+    Returns:
+        WordContext object with full metadata.
+    """
+    return WordContext(
+        line=line.strip(),
+        track=song_title,
+        album=album,
+        year=year,
+    )
+
+
+def extract_contexts_for_word(
+    tokens_with_positions: list[TokenWithPosition],
+    word: str,
+    mode: ContextsMode,
+    max_contexts: int = 3,
+    window_size: int = 2,
+) -> tuple[str, ...] | tuple[WordContext, ...] | None:
+    """Extract contexts for a specific word from tokens with positions.
+
+    Args:
+        tokens_with_positions: List of tokens with their position information.
+        word: The target word to find contexts for.
+        mode: Context extraction mode (none/short/full).
+        max_contexts: Maximum number of contexts to extract.
+        window_size: Window size for short context mode.
+
+    Returns:
+        Tuple of context strings (short mode) or WordContext objects (full mode),
+        or None if mode is 'none'.
+    """
+    if mode == ContextsMode.NONE:
+        return None
+
+    word_lower = word.lower()
+
+    # Find all occurrences of the word
+    occurrences: list[TokenWithPosition] = [
+        token for token in tokens_with_positions if token.token.lower() == word_lower
+    ]
+
+    if not occurrences:
+        return None
+
+    # Deduplicate by (song_id, line_index) to avoid duplicate contexts from same line
+    seen_lines: set[tuple[int, int]] = set()
+    unique_occurrences: list[TokenWithPosition] = []
+    for occ in occurrences:
+        key = (occ.song_id, occ.line_index)
+        if key not in seen_lines:
+            seen_lines.add(key)
+            unique_occurrences.append(occ)
+
+    # Limit to max_contexts
+    selected = unique_occurrences[:max_contexts]
+
+    if mode == ContextsMode.SHORT:
+        contexts: list[str] = []
+        for occ in selected:
+            context = extract_short_context(occ.original_line, word, window_size)
+            contexts.append(context)
+        return tuple(contexts)
+
+    elif mode == ContextsMode.FULL:
+        full_contexts: list[WordContext] = []
+        for occ in selected:
+            full_ctx = extract_full_context(
+                line=occ.original_line,
+                song_title=occ.song_title,
+                album=None,  # Not available in current model
+                year=None,  # Not available in current model
+            )
+            full_contexts.append(full_ctx)
+        return tuple(full_contexts)
+
+    return None
+
+
+def group_tokens_by_word(
+    tokens_with_positions: list[TokenWithPosition],
+) -> dict[str, list[TokenWithPosition]]:
+    """Group tokens by their normalized word.
+
+    Args:
+        tokens_with_positions: List of tokens with position information.
+
+    Returns:
+        Dictionary mapping lowercase words to their token occurrences.
+    """
+    groups: dict[str, list[TokenWithPosition]] = {}
+    for token in tokens_with_positions:
+        word_lower = token.token.lower()
+        if word_lower not in groups:
+            groups[word_lower] = []
+        groups[word_lower].append(token)
+    return groups

--- a/src/barscan/analyzer/models.py
+++ b/src/barscan/analyzer/models.py
@@ -1,8 +1,19 @@
 """Pydantic models for text analysis."""
 
+from __future__ import annotations
+
 from datetime import datetime
+from enum import StrEnum
 
 from pydantic import BaseModel, Field
+
+
+class ContextsMode(StrEnum):
+    """Context extraction mode for copyright handling."""
+
+    NONE = "none"
+    SHORT = "short"
+    FULL = "full"
 
 
 class WordFrequency(BaseModel, frozen=True):
@@ -28,6 +39,12 @@ class AnalysisConfig(BaseModel, frozen=True):
         remove_stop_words: Whether to filter out stop words.
         custom_stop_words: Additional stop words to filter.
         language: Language for NLTK processing.
+        compute_tfidf: Whether to compute TF-IDF scores.
+        compute_pos: Whether to compute POS tags.
+        compute_sentiment: Whether to compute sentiment scores.
+        detect_slang: Whether to detect slang words.
+        contexts_mode: Context extraction mode (none/short/full).
+        max_contexts_per_word: Maximum number of contexts per word.
     """
 
     min_word_length: int = Field(default=2, ge=1, description="Minimum word length to include")
@@ -37,6 +54,18 @@ class AnalysisConfig(BaseModel, frozen=True):
         default_factory=frozenset, description="Additional stop words to filter"
     )
     language: str = Field(default="english", description="Language for NLTK processing")
+
+    # Enhanced NLP analysis options
+    compute_tfidf: bool = Field(default=False, description="Whether to compute TF-IDF scores")
+    compute_pos: bool = Field(default=False, description="Whether to compute POS tags")
+    compute_sentiment: bool = Field(default=False, description="Whether to compute sentiment")
+    detect_slang: bool = Field(default=False, description="Whether to detect slang words")
+    contexts_mode: ContextsMode = Field(
+        default=ContextsMode.NONE, description="Context extraction mode"
+    )
+    max_contexts_per_word: int = Field(
+        default=3, ge=1, le=10, description="Maximum contexts per word"
+    )
 
 
 class AnalysisResult(BaseModel, frozen=True):
@@ -109,3 +138,41 @@ class AggregateAnalysisResult(BaseModel, frozen=True):
             Tuple of top N WordFrequency items.
         """
         return self.frequencies[:n]
+
+
+class TokenWithPosition(BaseModel, frozen=True):
+    """A token with its position information for context extraction.
+
+    Attributes:
+        token: The normalized word token.
+        line_index: Zero-based line index in the lyrics.
+        word_index: Zero-based word index within the line.
+        original_line: The original line text (before normalization).
+        song_id: Genius song ID.
+        song_title: Title of the song.
+    """
+
+    token: str = Field(..., description="The normalized word token")
+    line_index: int = Field(..., ge=0, description="Zero-based line index")
+    word_index: int = Field(..., ge=0, description="Zero-based word index within line")
+    original_line: str = Field(..., description="Original line text")
+    song_id: int = Field(..., description="Genius song ID")
+    song_title: str = Field(..., description="Title of the song")
+
+
+class WordContext(BaseModel, frozen=True):
+    """A context example for a word occurrence.
+
+    Used in 'full' context mode to provide rich metadata.
+
+    Attributes:
+        line: The lyrics line containing the word.
+        track: The song title.
+        album: Album name (optional, may not be available).
+        year: Release year (optional, may not be available).
+    """
+
+    line: str = Field(..., description="The lyrics line containing the word")
+    track: str = Field(..., description="The song title")
+    album: str | None = Field(default=None, description="Album name if available")
+    year: int | None = Field(default=None, description="Release year if available")

--- a/src/barscan/analyzer/pos.py
+++ b/src/barscan/analyzer/pos.py
@@ -1,0 +1,143 @@
+"""Part-of-speech tagging for lyrics analysis."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING
+
+import nltk
+
+from barscan.exceptions import NLTKResourceError
+
+if TYPE_CHECKING:
+    pass
+
+# Penn Treebank POS tag to simple label mapping
+POS_TAG_MAP: dict[str, str] = {
+    # Nouns
+    "NN": "noun",
+    "NNS": "noun",
+    "NNP": "noun",
+    "NNPS": "noun",
+    # Verbs
+    "VB": "verb",
+    "VBD": "verb",
+    "VBG": "verb",
+    "VBN": "verb",
+    "VBP": "verb",
+    "VBZ": "verb",
+    # Adjectives
+    "JJ": "adjective",
+    "JJR": "adjective",
+    "JJS": "adjective",
+    # Adverbs
+    "RB": "adverb",
+    "RBR": "adverb",
+    "RBS": "adverb",
+    # Pronouns
+    "PRP": "pronoun",
+    "PRP$": "pronoun",
+    "WP": "pronoun",
+    "WP$": "pronoun",
+    # Prepositions
+    "IN": "preposition",
+    "TO": "preposition",
+    # Conjunctions
+    "CC": "conjunction",
+    # Determiners
+    "DT": "determiner",
+    "PDT": "determiner",
+    "WDT": "determiner",
+    # Interjections
+    "UH": "interjection",
+    # Modals
+    "MD": "modal",
+    # Other
+    "CD": "number",
+    "EX": "existential",
+    "FW": "foreign",
+    "LS": "list",
+    "POS": "possessive",
+    "RP": "particle",
+    "SYM": "symbol",
+    "WRB": "wh-adverb",
+}
+
+
+def ensure_pos_resources() -> None:
+    """Ensure required NLTK resources for POS tagging are downloaded.
+
+    Raises:
+        NLTKResourceError: If resources cannot be downloaded.
+    """
+    resources = [
+        ("taggers/averaged_perceptron_tagger_eng", "averaged_perceptron_tagger_eng"),
+    ]
+    for path, name in resources:
+        try:
+            nltk.data.find(path)
+        except LookupError:
+            try:
+                nltk.download(name, quiet=True)
+            except Exception as e:
+                raise NLTKResourceError(f"Failed to download NLTK resource '{name}': {e}") from e
+
+
+def get_pos_tags(tokens: list[str]) -> dict[str, str]:
+    """Get POS tags for a list of tokens.
+
+    Returns the most common POS tag for each unique word. Tags are mapped to
+    simple labels (noun, verb, adjective, etc.) for readability.
+
+    Args:
+        tokens: List of word tokens.
+
+    Returns:
+        Dictionary mapping words to their POS tags (simple labels).
+
+    Raises:
+        NLTKResourceError: If POS tagger is not available.
+    """
+    if not tokens:
+        return {}
+
+    ensure_pos_resources()
+
+    try:
+        # Get POS tags for all tokens
+        tagged = nltk.pos_tag(tokens)
+    except LookupError as e:
+        raise NLTKResourceError(f"NLTK POS tagging failed: {e}") from e
+
+    # Aggregate: find most common tag for each unique word
+    word_tags: dict[str, Counter[str]] = {}
+    for word, tag in tagged:
+        word_lower = word.lower()
+        if word_lower not in word_tags:
+            word_tags[word_lower] = Counter()
+        word_tags[word_lower][tag] += 1
+
+    # Get most common tag for each word and map to simple label
+    result: dict[str, str] = {}
+    for word, tag_counts in word_tags.items():
+        most_common_tag = tag_counts.most_common(1)[0][0]
+        # Map to simple label, default to the raw tag if not in map
+        result[word] = POS_TAG_MAP.get(most_common_tag, most_common_tag.lower())
+
+    return result
+
+
+def get_pos_tag(word: str) -> str:
+    """Get POS tag for a single word.
+
+    Args:
+        word: The word to tag.
+
+    Returns:
+        Simple POS label (noun, verb, etc.).
+
+    Raises:
+        NLTKResourceError: If POS tagger is not available.
+    """
+    tags = get_pos_tags([word])
+    return tags.get(word.lower(), "unknown")

--- a/src/barscan/analyzer/sentiment.py
+++ b/src/barscan/analyzer/sentiment.py
@@ -1,0 +1,120 @@
+"""Sentiment analysis using NLTK VADER."""
+
+from __future__ import annotations
+
+import nltk
+from nltk.sentiment.vader import SentimentIntensityAnalyzer
+
+from barscan.exceptions import NLTKResourceError
+
+# Singleton instance for performance
+_sia: SentimentIntensityAnalyzer | None = None
+
+
+def ensure_sentiment_resources() -> None:
+    """Ensure required NLTK resources for sentiment analysis are downloaded.
+
+    Raises:
+        NLTKResourceError: If resources cannot be downloaded.
+    """
+    resources = [
+        ("sentiment/vader_lexicon.zip", "vader_lexicon"),
+    ]
+    for path, name in resources:
+        try:
+            nltk.data.find(path)
+        except LookupError:
+            try:
+                nltk.download(name, quiet=True)
+            except Exception as e:
+                raise NLTKResourceError(f"Failed to download NLTK resource '{name}': {e}") from e
+
+
+def _get_analyzer() -> SentimentIntensityAnalyzer:
+    """Get or create the VADER sentiment analyzer.
+
+    Returns:
+        SentimentIntensityAnalyzer instance.
+
+    Raises:
+        NLTKResourceError: If VADER lexicon is not available.
+    """
+    global _sia
+    if _sia is None:
+        ensure_sentiment_resources()
+        try:
+            _sia = SentimentIntensityAnalyzer()
+        except LookupError as e:
+            raise NLTKResourceError(f"NLTK VADER initialization failed: {e}") from e
+    return _sia
+
+
+def analyze_sentiment(text: str) -> tuple[str, float]:
+    """Analyze sentiment of text.
+
+    Args:
+        text: Text to analyze (word, phrase, or sentence).
+
+    Returns:
+        Tuple of (category, compound_score) where:
+        - category: 'positive', 'negative', or 'neutral'
+        - compound_score: VADER compound score from -1.0 to 1.0
+
+    Raises:
+        NLTKResourceError: If VADER is not available.
+    """
+    sia = _get_analyzer()
+    scores = sia.polarity_scores(text)
+    compound = scores["compound"]
+
+    # Classify based on compound score thresholds
+    if compound >= 0.05:
+        category = "positive"
+    elif compound <= -0.05:
+        category = "negative"
+    else:
+        category = "neutral"
+
+    return (category, round(compound, 4))
+
+
+def analyze_word_sentiment(word: str) -> tuple[str, float]:
+    """Analyze sentiment of a single word.
+
+    Note: Single words often have neutral sentiment as VADER is designed
+    for sentences. Context matters for accurate sentiment analysis.
+
+    Args:
+        word: Word to analyze.
+
+    Returns:
+        Tuple of (category, compound_score).
+
+    Raises:
+        NLTKResourceError: If VADER is not available.
+    """
+    return analyze_sentiment(word)
+
+
+def get_sentiment_scores(words: list[str]) -> dict[str, tuple[str, float]]:
+    """Get sentiment scores for a list of words.
+
+    Args:
+        words: List of words to analyze.
+
+    Returns:
+        Dictionary mapping words to (category, compound_score) tuples.
+
+    Raises:
+        NLTKResourceError: If VADER is not available.
+    """
+    if not words:
+        return {}
+
+    result: dict[str, tuple[str, float]] = {}
+    for word in set(words):  # Deduplicate
+        word_lower = word.lower()
+        if word_lower not in result:
+            result[word_lower] = analyze_word_sentiment(word_lower)
+
+    return result

--- a/src/barscan/analyzer/slang.py
+++ b/src/barscan/analyzer/slang.py
@@ -1,0 +1,240 @@
+"""Slang word detection for lyrics analysis."""
+
+from __future__ import annotations
+
+# Curated slang dictionary for music/hip-hop lyrics
+# This is a representative set - can be extended via configuration
+SLANG_WORDS: frozenset[str] = frozenset(
+    {
+        # Common contractions/informal
+        "ain't",
+        "gonna",
+        "wanna",
+        "gotta",
+        "kinda",
+        "sorta",
+        "lemme",
+        "gimme",
+        "dunno",
+        "tryna",
+        "finna",
+        "boutta",
+        "shoulda",
+        "coulda",
+        "woulda",
+        "ima",
+        "imma",
+        "aint",
+        # Pronouns/addressing
+        "ya",
+        "yo",
+        "yall",
+        "y'all",
+        "em",
+        "'em",
+        "da",
+        "tha",
+        "dat",
+        "dis",
+        "dem",
+        "dey",
+        "wit",
+        "wid",
+        # People
+        "bruh",
+        "bro",
+        "homie",
+        "homies",
+        "dawg",
+        "fam",
+        "cuz",
+        "playa",
+        "pimp",
+        "shorty",
+        "shawty",
+        "mama",
+        "mami",
+        "papi",
+        "bae",
+        "boo",
+        # Actions/states
+        "chillin",
+        "trippin",
+        "flexin",
+        "stuntin",
+        "ballin",
+        "poppin",
+        "rockin",
+        "vibin",
+        "slidin",
+        "drippin",
+        "sippin",
+        "hittin",
+        "whippin",
+        # Adjectives/interjections
+        "lit",
+        "dope",
+        "sick",
+        "fire",
+        "tight",
+        "wack",
+        "whack",
+        "sus",
+        "bougie",
+        "boujee",
+        "fly",
+        "fresh",
+        "cold",
+        "icy",
+        "wavy",
+        "lowkey",
+        "highkey",
+        "deadass",
+        "hype",
+        "hyped",
+        # Money/success
+        "bands",
+        "racks",
+        "stacks",
+        "guap",
+        "bread",
+        "cheddar",
+        "dough",
+        "paper",
+        "moolah",
+        "cake",
+        "gwap",
+        "benjis",
+        "bucks",
+        "hunnids",
+        # Lifestyle
+        "flex",
+        "drip",
+        "swag",
+        "clout",
+        "hustle",
+        "grind",
+        "trap",
+        "hood",
+        "block",
+        "turf",
+        "whip",
+        "ride",
+        "crib",
+        "pad",
+        # Expressions
+        "bet",
+        "cap",
+        "nocap",
+        "facts",
+        "word",
+        "aight",
+        "ight",
+        "iight",
+        "yeet",
+        "slay",
+        "bop",
+        "slap",
+        "slaps",
+        "bussin",
+        "goat",
+        "goated",
+        "goats",
+        "fye",
+        # Negatives/criticism
+        "hater",
+        "haters",
+        "opps",
+        "ops",
+        "snitch",
+        "fake",
+        "lame",
+        "corny",
+        "bogus",
+        # Misc slang
+        "vibe",
+        "vibes",
+        "mood",
+        "wave",
+        "sauce",
+        "drako",
+        "choppa",
+        "glizzy",
+        "thang",
+        "thangs",
+        "nah",
+        "yuh",
+        "yeah",
+        "ayy",
+        "aye",
+        "huh",
+        "uh",
+        "uhh",
+        "mmm",
+        "ooh",
+        "woah",
+        "skrrt",
+        "skrt",
+        "brr",
+        "grr",
+    }
+)
+
+
+def is_slang(word: str, additional_slang: frozenset[str] | None = None) -> bool:
+    """Check if a word is slang.
+
+    Args:
+        word: Word to check.
+        additional_slang: Optional additional slang words to include.
+
+    Returns:
+        True if the word is in the slang dictionary.
+    """
+    word_lower = word.lower()
+    slang_set = SLANG_WORDS | (additional_slang or frozenset())
+    return word_lower in slang_set
+
+
+def detect_slang_words(
+    words: list[str],
+    additional_slang: frozenset[str] | None = None,
+) -> dict[str, bool]:
+    """Detect slang words in a list.
+
+    Args:
+        words: List of words to check.
+        additional_slang: Optional additional slang words to include.
+
+    Returns:
+        Dictionary mapping words to their slang status.
+    """
+    if not words:
+        return {}
+
+    slang_set = SLANG_WORDS | (additional_slang or frozenset())
+    result: dict[str, bool] = {}
+
+    for word in set(words):  # Deduplicate
+        word_lower = word.lower()
+        if word_lower not in result:
+            result[word_lower] = word_lower in slang_set
+
+    return result
+
+
+def get_slang_count(
+    words: list[str],
+    additional_slang: frozenset[str] | None = None,
+) -> int:
+    """Count slang words in a list.
+
+    Args:
+        words: List of words to check.
+        additional_slang: Optional additional slang words to include.
+
+    Returns:
+        Number of slang word occurrences.
+    """
+    slang_set = SLANG_WORDS | (additional_slang or frozenset())
+    return sum(1 for word in words if word.lower() in slang_set)

--- a/src/barscan/analyzer/tfidf.py
+++ b/src/barscan/analyzer/tfidf.py
@@ -1,0 +1,146 @@
+"""TF-IDF calculation for lyrics corpus."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+def calculate_document_frequencies(
+    word_counts_per_song: list[Counter[str]],
+) -> dict[str, int]:
+    """Calculate document frequency for each word.
+
+    Document frequency is the number of songs that contain each word.
+
+    Args:
+        word_counts_per_song: List of Counter objects, one per song.
+
+    Returns:
+        Dictionary mapping words to their document frequency.
+    """
+    doc_freq: Counter[str] = Counter()
+    for word_counts in word_counts_per_song:
+        # Each word counts once per document, regardless of frequency
+        for word in word_counts:
+            doc_freq[word] += 1
+    return dict(doc_freq)
+
+
+def calculate_idf(
+    document_frequency: int,
+    total_documents: int,
+) -> float:
+    """Calculate IDF (Inverse Document Frequency) score.
+
+    Uses log(N/df) formula where N is total documents and df is document frequency.
+    Returns 0 if the word appears in no documents.
+
+    Args:
+        document_frequency: Number of documents containing the word.
+        total_documents: Total number of documents in corpus.
+
+    Returns:
+        IDF score (always >= 0).
+    """
+    if document_frequency == 0 or total_documents == 0:
+        return 0.0
+    return math.log(total_documents / document_frequency)
+
+
+def calculate_tf(word_count: int, total_words: int) -> float:
+    """Calculate TF (Term Frequency) score.
+
+    Uses raw term frequency divided by total words in document.
+
+    Args:
+        word_count: Number of times the word appears.
+        total_words: Total words in the document/corpus.
+
+    Returns:
+        TF score (0.0 to 1.0).
+    """
+    if total_words == 0:
+        return 0.0
+    return word_count / total_words
+
+
+def calculate_tfidf_scores(
+    word_counts: dict[str, int],
+    total_words: int,
+    document_frequencies: dict[str, int],
+    total_documents: int,
+    normalize: bool = True,
+) -> dict[str, float]:
+    """Calculate TF-IDF scores for all words.
+
+    Args:
+        word_counts: Dictionary mapping words to their counts.
+        total_words: Total words in the corpus.
+        document_frequencies: Dictionary mapping words to their document frequency.
+        total_documents: Total number of documents in corpus.
+        normalize: Whether to normalize scores to 0.0-1.0 range.
+
+    Returns:
+        Dictionary mapping words to their TF-IDF scores.
+    """
+    if not word_counts:
+        return {}
+
+    tfidf_scores: dict[str, float] = {}
+
+    for word, count in word_counts.items():
+        tf = calculate_tf(count, total_words)
+        doc_freq = document_frequencies.get(word, 0)
+        idf = calculate_idf(doc_freq, total_documents)
+        tfidf_scores[word] = tf * idf
+
+    if normalize and tfidf_scores:
+        max_score = max(tfidf_scores.values())
+        if max_score > 0:
+            tfidf_scores = {
+                word: round(score / max_score, 4) for word, score in tfidf_scores.items()
+            }
+
+    return tfidf_scores
+
+
+def calculate_corpus_tfidf(
+    word_counts_per_song: list[Counter[str]],
+    aggregate_counts: dict[str, int],
+    total_words: int,
+    normalize: bool = True,
+) -> dict[str, float]:
+    """Calculate TF-IDF scores for an aggregated corpus.
+
+    This is the main function to use when computing TF-IDF for WordGrain output.
+    It treats each song as a document and calculates TF-IDF based on:
+    - TF: word frequency in the entire corpus
+    - IDF: inverse of how many songs contain the word
+
+    Args:
+        word_counts_per_song: List of Counter objects, one per song.
+        aggregate_counts: Aggregated word counts across all songs.
+        total_words: Total words in the entire corpus.
+        normalize: Whether to normalize scores to 0.0-1.0 range.
+
+    Returns:
+        Dictionary mapping words to their TF-IDF scores.
+    """
+    total_documents = len(word_counts_per_song)
+    if total_documents == 0:
+        return {}
+
+    doc_frequencies = calculate_document_frequencies(word_counts_per_song)
+
+    return calculate_tfidf_scores(
+        word_counts=aggregate_counts,
+        total_words=total_words,
+        document_frequencies=doc_frequencies,
+        total_documents=total_documents,
+        normalize=normalize,
+    )

--- a/src/barscan/output/__init__.py
+++ b/src/barscan/output/__init__.py
@@ -9,6 +9,7 @@ from barscan.output.wordgrain import (
     generate_filename,
     slugify,
     to_wordgrain,
+    to_wordgrain_enhanced,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "generate_filename",
     "slugify",
     "to_wordgrain",
+    "to_wordgrain_enhanced",
 ]

--- a/src/barscan/output/wordgrain.py
+++ b/src/barscan/output/wordgrain.py
@@ -11,12 +11,24 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from collections import Counter
 from datetime import datetime
 from importlib.metadata import version
 
 from pydantic import BaseModel, Field
 
-from barscan.analyzer.models import AggregateAnalysisResult
+from barscan.analyzer.context import extract_contexts_for_word
+from barscan.analyzer.models import (
+    AggregateAnalysisResult,
+    AnalysisConfig,
+    ContextsMode,
+    TokenWithPosition,
+    WordContext,
+)
+from barscan.analyzer.pos import get_pos_tags
+from barscan.analyzer.sentiment import get_sentiment_scores
+from barscan.analyzer.slang import detect_slang_words
+from barscan.analyzer.tfidf import calculate_corpus_tfidf
 
 WORDGRAIN_SCHEMA_URL = "https://mumbl.dev/schemas/wordgrain/v0.1.0"
 
@@ -28,11 +40,29 @@ class WordGrainGrain(BaseModel, frozen=True):
         word: The vocabulary word.
         frequency: Raw occurrence count.
         frequency_normalized: Occurrences per 10,000 words.
+        tfidf: TF-IDF score (0.0-1.0), optional.
+        pos: Part-of-speech tag, optional.
+        sentiment: Sentiment category (positive/negative/neutral), optional.
+        sentiment_score: VADER compound score (-1.0 to 1.0), optional.
+        is_slang: Whether the word is slang, optional.
+        contexts: Example usage contexts, optional.
     """
 
     word: str = Field(..., min_length=1, description="The vocabulary word")
     frequency: int = Field(..., ge=0, description="Raw occurrence count")
     frequency_normalized: float = Field(..., ge=0.0, description="Occurrences per 10,000 words")
+
+    # Enhanced NLP fields (all optional for backward compatibility)
+    tfidf: float | None = Field(default=None, ge=0.0, le=1.0, description="TF-IDF score")
+    pos: str | None = Field(default=None, description="Part-of-speech tag")
+    sentiment: str | None = Field(default=None, description="Sentiment category")
+    sentiment_score: float | None = Field(
+        default=None, ge=-1.0, le=1.0, description="VADER compound score"
+    )
+    is_slang: bool | None = Field(default=None, description="Whether word is slang")
+    contexts: tuple[str, ...] | tuple[WordContext, ...] | None = Field(
+        default=None, description="Example usage contexts"
+    )
 
 
 class WordGrainMeta(BaseModel, frozen=True):
@@ -187,4 +217,128 @@ def export_wordgrain(
     return document.model_dump_json(
         by_alias=True,
         indent=indent,
+        exclude_none=True,
+    )
+
+
+def to_wordgrain_enhanced(
+    aggregate: AggregateAnalysisResult,
+    config: AnalysisConfig,
+    word_counts_per_song: list[Counter[str]] | None = None,
+    tokens_with_positions: list[TokenWithPosition] | None = None,
+    language: str = "en",
+) -> WordGrainDocument:
+    """Convert analysis results to WordGrain format with enhanced NLP fields.
+
+    This function computes additional NLP fields based on the config:
+    - TF-IDF scores (requires word_counts_per_song)
+    - POS tags
+    - Sentiment scores
+    - Slang detection
+    - Context extraction (requires tokens_with_positions)
+
+    Args:
+        aggregate: Aggregated analysis results.
+        config: Analysis configuration with NLP options enabled.
+        word_counts_per_song: Word counts per song for TF-IDF calculation.
+        tokens_with_positions: Tokens with position info for context extraction.
+        language: ISO 639-1 language code.
+
+    Returns:
+        WordGrainDocument with enhanced NLP fields.
+    """
+    # Collect all words for batch processing
+    words = [freq.word for freq in aggregate.frequencies]
+
+    # Compute TF-IDF if enabled
+    tfidf_scores: dict[str, float] = {}
+    if config.compute_tfidf and word_counts_per_song:
+        aggregate_counts = {freq.word: freq.count for freq in aggregate.frequencies}
+        tfidf_scores = calculate_corpus_tfidf(
+            word_counts_per_song=word_counts_per_song,
+            aggregate_counts=aggregate_counts,
+            total_words=aggregate.total_words,
+            normalize=True,
+        )
+
+    # Compute POS tags if enabled
+    pos_tags: dict[str, str] = {}
+    if config.compute_pos:
+        pos_tags = get_pos_tags(words)
+
+    # Compute sentiment if enabled
+    sentiment_scores: dict[str, tuple[str, float]] = {}
+    if config.compute_sentiment:
+        sentiment_scores = get_sentiment_scores(words)
+
+    # Detect slang if enabled
+    slang_flags: dict[str, bool] = {}
+    if config.detect_slang:
+        slang_flags = detect_slang_words(words)
+
+    # Build grains with enhanced fields
+    grains: list[WordGrainGrain] = []
+    for freq in aggregate.frequencies:
+        word = freq.word
+        word_lower = word.lower()
+
+        # Calculate normalized frequency
+        if aggregate.total_words > 0:
+            normalized = round((freq.count / aggregate.total_words) * 10000, 2)
+        else:
+            normalized = 0.0
+
+        # Get TF-IDF
+        tfidf = tfidf_scores.get(word) if config.compute_tfidf else None
+
+        # Get POS
+        pos = pos_tags.get(word_lower) if config.compute_pos else None
+
+        # Get sentiment
+        sentiment = None
+        sentiment_score = None
+        if config.compute_sentiment and word_lower in sentiment_scores:
+            sentiment, sentiment_score = sentiment_scores[word_lower]
+
+        # Get slang flag
+        is_slang = slang_flags.get(word_lower) if config.detect_slang else None
+
+        # Get contexts
+        contexts: tuple[str, ...] | tuple[WordContext, ...] | None = None
+        if config.contexts_mode != ContextsMode.NONE and tokens_with_positions:
+            contexts = extract_contexts_for_word(
+                tokens_with_positions=tokens_with_positions,
+                word=word,
+                mode=config.contexts_mode,
+                max_contexts=config.max_contexts_per_word,
+            )
+
+        grains.append(
+            WordGrainGrain(
+                word=word,
+                frequency=freq.count,
+                frequency_normalized=normalized,
+                tfidf=tfidf,
+                pos=pos,
+                sentiment=sentiment,
+                sentiment_score=sentiment_score,
+                is_slang=is_slang,
+                contexts=contexts,
+            )
+        )
+
+    # Build metadata
+    meta = WordGrainMeta(
+        source="genius",
+        artist=aggregate.artist_name,
+        generated_at=aggregate.analyzed_at,
+        corpus_size=aggregate.songs_analyzed,
+        total_words=aggregate.total_words,
+        generator=_get_generator_string(),
+        language=language,
+    )
+
+    return WordGrainDocument(
+        meta=meta,
+        grains=tuple(grains),
     )

--- a/tests/test_analyzer/test_context.py
+++ b/tests/test_analyzer/test_context.py
@@ -1,0 +1,271 @@
+"""Tests for context extraction module."""
+
+import pytest
+
+from barscan.analyzer.context import (
+    extract_contexts_for_word,
+    extract_full_context,
+    extract_short_context,
+    group_tokens_by_word,
+)
+from barscan.analyzer.models import ContextsMode, TokenWithPosition, WordContext
+
+
+class TestExtractShortContext:
+    """Tests for extract_short_context function."""
+
+    def test_word_in_middle(self) -> None:
+        """Test extracting context when word is in the middle."""
+        line = "I love you baby"
+        result = extract_short_context(line, "love", window_size=1)
+        assert "I" in result
+        assert "love" in result
+        assert "you" in result
+
+    def test_word_at_start(self) -> None:
+        """Test extracting context when word is at the start."""
+        line = "Love is all you need"
+        result = extract_short_context(line, "love", window_size=2)
+        assert "Love" in result
+        assert "is" in result
+        # Should not have leading ellipsis
+        assert not result.startswith("...")
+
+    def test_word_at_end(self) -> None:
+        """Test extracting context when word is at the end."""
+        line = "All you need is love"
+        result = extract_short_context(line, "love", window_size=2)
+        assert "love" in result
+        assert "is" in result
+        # Should not have trailing ellipsis
+        assert not result.endswith("...")
+
+    def test_ellipsis_markers(self) -> None:
+        """Test that ellipsis markers are added when needed."""
+        line = "one two three four five six seven eight"
+        result = extract_short_context(line, "five", window_size=1)
+        assert result.startswith("...")
+        assert result.endswith("...")
+
+    def test_word_not_found(self) -> None:
+        """Test when word is not found in line."""
+        line = "I love music"
+        result = extract_short_context(line, "xyz", window_size=2)
+        # Should return truncated line
+        assert result is not None
+
+    def test_case_insensitive(self) -> None:
+        """Test case-insensitive word matching."""
+        line = "I LOVE you"
+        result = extract_short_context(line, "love", window_size=1)
+        assert "LOVE" in result
+
+
+class TestExtractFullContext:
+    """Tests for extract_full_context function."""
+
+    def test_basic_context(self) -> None:
+        """Test basic full context extraction."""
+        result = extract_full_context(
+            line="Every day I'm hustlin'",
+            song_title="Hustlin'",
+        )
+        assert isinstance(result, WordContext)
+        assert result.line == "Every day I'm hustlin'"
+        assert result.track == "Hustlin'"
+        assert result.album is None
+        assert result.year is None
+
+    def test_with_album_and_year(self) -> None:
+        """Test full context with album and year."""
+        result = extract_full_context(
+            line="Every day I'm hustlin'",
+            song_title="Hustlin'",
+            album="Port of Miami",
+            year=2006,
+        )
+        assert result.album == "Port of Miami"
+        assert result.year == 2006
+
+    def test_strips_whitespace(self) -> None:
+        """Test that line is stripped of whitespace."""
+        result = extract_full_context(
+            line="  Some lyrics here  ",
+            song_title="Test Song",
+        )
+        assert result.line == "Some lyrics here"
+
+
+class TestExtractContextsForWord:
+    """Tests for extract_contexts_for_word function."""
+
+    @pytest.fixture
+    def sample_tokens(self) -> list[TokenWithPosition]:
+        """Create sample tokens with positions."""
+        return [
+            TokenWithPosition(
+                token="love",
+                line_index=0,
+                word_index=1,
+                original_line="I love you",
+                song_id=1,
+                song_title="Song 1",
+            ),
+            TokenWithPosition(
+                token="you",
+                line_index=0,
+                word_index=2,
+                original_line="I love you",
+                song_id=1,
+                song_title="Song 1",
+            ),
+            TokenWithPosition(
+                token="love",
+                line_index=1,
+                word_index=0,
+                original_line="Love is all",
+                song_id=1,
+                song_title="Song 1",
+            ),
+            TokenWithPosition(
+                token="love",
+                line_index=0,
+                word_index=2,
+                original_line="My endless love",
+                song_id=2,
+                song_title="Song 2",
+            ),
+        ]
+
+    def test_none_mode(self, sample_tokens: list[TokenWithPosition]) -> None:
+        """Test that NONE mode returns None."""
+        result = extract_contexts_for_word(
+            tokens_with_positions=sample_tokens,
+            word="love",
+            mode=ContextsMode.NONE,
+        )
+        assert result is None
+
+    def test_short_mode(self, sample_tokens: list[TokenWithPosition]) -> None:
+        """Test SHORT mode returns string contexts."""
+        result = extract_contexts_for_word(
+            tokens_with_positions=sample_tokens,
+            word="love",
+            mode=ContextsMode.SHORT,
+            max_contexts=3,
+        )
+        assert result is not None
+        assert isinstance(result, tuple)
+        assert all(isinstance(ctx, str) for ctx in result)
+
+    def test_full_mode(self, sample_tokens: list[TokenWithPosition]) -> None:
+        """Test FULL mode returns WordContext objects."""
+        result = extract_contexts_for_word(
+            tokens_with_positions=sample_tokens,
+            word="love",
+            mode=ContextsMode.FULL,
+            max_contexts=3,
+        )
+        assert result is not None
+        assert isinstance(result, tuple)
+        assert all(isinstance(ctx, WordContext) for ctx in result)
+
+    def test_max_contexts_limit(self, sample_tokens: list[TokenWithPosition]) -> None:
+        """Test that max_contexts limits the number of results."""
+        result = extract_contexts_for_word(
+            tokens_with_positions=sample_tokens,
+            word="love",
+            mode=ContextsMode.SHORT,
+            max_contexts=2,
+        )
+        assert result is not None
+        assert len(result) <= 2
+
+    def test_word_not_found(self, sample_tokens: list[TokenWithPosition]) -> None:
+        """Test when word is not found in tokens."""
+        result = extract_contexts_for_word(
+            tokens_with_positions=sample_tokens,
+            word="xyz",
+            mode=ContextsMode.SHORT,
+        )
+        assert result is None
+
+    def test_case_insensitive(self, sample_tokens: list[TokenWithPosition]) -> None:
+        """Test case-insensitive word matching."""
+        result = extract_contexts_for_word(
+            tokens_with_positions=sample_tokens,
+            word="LOVE",
+            mode=ContextsMode.SHORT,
+        )
+        assert result is not None
+
+    def test_deduplicates_same_line(self, sample_tokens: list[TokenWithPosition]) -> None:
+        """Test that duplicate contexts from same line are deduplicated."""
+        # Add duplicate token on same line
+        tokens = sample_tokens + [
+            TokenWithPosition(
+                token="love",
+                line_index=0,
+                word_index=3,
+                original_line="I love you",
+                song_id=1,
+                song_title="Song 1",
+            ),
+        ]
+        result = extract_contexts_for_word(
+            tokens_with_positions=tokens,
+            word="love",
+            mode=ContextsMode.SHORT,
+            max_contexts=10,
+        )
+        # Should deduplicate by (song_id, line_index)
+        assert result is not None
+        # Count unique (song_id, line_index) pairs
+        assert len(result) == 3
+
+
+class TestGroupTokensByWord:
+    """Tests for group_tokens_by_word function."""
+
+    def test_empty_list(self) -> None:
+        """Test with empty token list."""
+        result = group_tokens_by_word([])
+        assert result == {}
+
+    def test_grouping(self) -> None:
+        """Test basic grouping."""
+        tokens = [
+            TokenWithPosition(
+                token="love", line_index=0, word_index=0,
+                original_line="love", song_id=1, song_title="Song"
+            ),
+            TokenWithPosition(
+                token="hate", line_index=0, word_index=1,
+                original_line="hate", song_id=1, song_title="Song"
+            ),
+            TokenWithPosition(
+                token="love", line_index=1, word_index=0,
+                original_line="love", song_id=1, song_title="Song"
+            ),
+        ]
+        result = group_tokens_by_word(tokens)
+        assert len(result) == 2
+        assert len(result["love"]) == 2
+        assert len(result["hate"]) == 1
+
+    def test_case_normalization(self) -> None:
+        """Test that words are normalized to lowercase."""
+        tokens = [
+            TokenWithPosition(
+                token="Love", line_index=0, word_index=0,
+                original_line="Love", song_id=1, song_title="Song"
+            ),
+            TokenWithPosition(
+                token="LOVE", line_index=1, word_index=0,
+                original_line="LOVE", song_id=1, song_title="Song"
+            ),
+        ]
+        result = group_tokens_by_word(tokens)
+        assert len(result) == 1
+        assert "love" in result
+        assert len(result["love"]) == 2

--- a/tests/test_analyzer/test_pos.py
+++ b/tests/test_analyzer/test_pos.py
@@ -1,0 +1,95 @@
+"""Tests for POS tagging module."""
+
+import pytest
+
+from barscan.analyzer.pos import POS_TAG_MAP, get_pos_tag, get_pos_tags
+
+
+class TestGetPosTags:
+    """Tests for get_pos_tags function."""
+
+    def test_empty_tokens(self) -> None:
+        """Test with empty token list."""
+        result = get_pos_tags([])
+        assert result == {}
+
+    def test_single_noun(self) -> None:
+        """Test tagging a single noun."""
+        result = get_pos_tags(["love"])
+        assert "love" in result
+        # Note: "love" can be noun or verb depending on context
+
+    def test_multiple_words(self) -> None:
+        """Test tagging multiple words."""
+        result = get_pos_tags(["love", "run", "beautiful", "quickly"])
+        assert len(result) == 4
+        assert "love" in result
+        assert "run" in result
+        assert "beautiful" in result
+        assert "quickly" in result
+
+    def test_returns_simple_labels(self) -> None:
+        """Test that results use simple labels from POS_TAG_MAP."""
+        result = get_pos_tags(["running", "cats", "beautiful"])
+        for word, tag in result.items():
+            # Tag should be a simple label or a lowercase raw tag
+            assert tag.islower() or tag in POS_TAG_MAP.values()
+
+    def test_duplicate_tokens(self) -> None:
+        """Test handling of duplicate tokens."""
+        result = get_pos_tags(["love", "love", "love"])
+        assert len(result) == 1
+        assert "love" in result
+
+    def test_most_common_tag(self) -> None:
+        """Test that most common tag is used for repeated words."""
+        # When a word appears multiple times in different positions,
+        # the most common tag should be returned
+        result = get_pos_tags(["love", "love", "love"])
+        assert "love" in result
+
+
+class TestGetPosTag:
+    """Tests for get_pos_tag function."""
+
+    def test_single_word(self) -> None:
+        """Test tagging a single word."""
+        result = get_pos_tag("love")
+        assert isinstance(result, str)
+
+    def test_unknown_word(self) -> None:
+        """Test tagging an unknown word."""
+        result = get_pos_tag("xyzzy123")
+        assert isinstance(result, str)
+
+
+class TestPosTagMap:
+    """Tests for POS_TAG_MAP constant."""
+
+    def test_noun_tags(self) -> None:
+        """Test noun tag mappings."""
+        assert POS_TAG_MAP["NN"] == "noun"
+        assert POS_TAG_MAP["NNS"] == "noun"
+        assert POS_TAG_MAP["NNP"] == "noun"
+        assert POS_TAG_MAP["NNPS"] == "noun"
+
+    def test_verb_tags(self) -> None:
+        """Test verb tag mappings."""
+        assert POS_TAG_MAP["VB"] == "verb"
+        assert POS_TAG_MAP["VBD"] == "verb"
+        assert POS_TAG_MAP["VBG"] == "verb"
+        assert POS_TAG_MAP["VBN"] == "verb"
+        assert POS_TAG_MAP["VBP"] == "verb"
+        assert POS_TAG_MAP["VBZ"] == "verb"
+
+    def test_adjective_tags(self) -> None:
+        """Test adjective tag mappings."""
+        assert POS_TAG_MAP["JJ"] == "adjective"
+        assert POS_TAG_MAP["JJR"] == "adjective"
+        assert POS_TAG_MAP["JJS"] == "adjective"
+
+    def test_adverb_tags(self) -> None:
+        """Test adverb tag mappings."""
+        assert POS_TAG_MAP["RB"] == "adverb"
+        assert POS_TAG_MAP["RBR"] == "adverb"
+        assert POS_TAG_MAP["RBS"] == "adverb"

--- a/tests/test_analyzer/test_sentiment.py
+++ b/tests/test_analyzer/test_sentiment.py
@@ -1,0 +1,119 @@
+"""Tests for sentiment analysis module."""
+
+import pytest
+
+from barscan.analyzer.sentiment import (
+    analyze_sentiment,
+    analyze_word_sentiment,
+    get_sentiment_scores,
+)
+
+
+class TestAnalyzeSentiment:
+    """Tests for analyze_sentiment function."""
+
+    def test_positive_word(self) -> None:
+        """Test sentiment analysis of a positive word."""
+        category, score = analyze_sentiment("love")
+        assert category == "positive"
+        assert score > 0
+
+    def test_negative_word(self) -> None:
+        """Test sentiment analysis of a negative word."""
+        category, score = analyze_sentiment("hate")
+        assert category == "negative"
+        assert score < 0
+
+    def test_neutral_word(self) -> None:
+        """Test sentiment analysis of a neutral word."""
+        category, score = analyze_sentiment("the")
+        assert category == "neutral"
+        assert -0.05 <= score <= 0.05
+
+    def test_positive_sentence(self) -> None:
+        """Test sentiment analysis of a positive sentence."""
+        category, score = analyze_sentiment("I love this beautiful day")
+        assert category == "positive"
+        assert score > 0
+
+    def test_negative_sentence(self) -> None:
+        """Test sentiment analysis of a negative sentence."""
+        category, score = analyze_sentiment("This is terrible and awful")
+        assert category == "negative"
+        assert score < 0
+
+    def test_score_range(self) -> None:
+        """Test that scores are within valid range."""
+        category, score = analyze_sentiment("amazing wonderful great")
+        assert -1.0 <= score <= 1.0
+
+    def test_score_rounding(self) -> None:
+        """Test that scores are properly rounded."""
+        category, score = analyze_sentiment("love")
+        # Score should be rounded to 4 decimal places
+        score_str = str(score)
+        if "." in score_str:
+            decimals = len(score_str.split(".")[1])
+            assert decimals <= 4
+
+
+class TestAnalyzeWordSentiment:
+    """Tests for analyze_word_sentiment function."""
+
+    def test_single_word(self) -> None:
+        """Test analyzing a single word."""
+        category, score = analyze_word_sentiment("happy")
+        assert isinstance(category, str)
+        assert isinstance(score, float)
+
+    def test_returns_tuple(self) -> None:
+        """Test that function returns a tuple."""
+        result = analyze_word_sentiment("love")
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+
+class TestGetSentimentScores:
+    """Tests for get_sentiment_scores function."""
+
+    def test_empty_list(self) -> None:
+        """Test with empty word list."""
+        result = get_sentiment_scores([])
+        assert result == {}
+
+    def test_single_word(self) -> None:
+        """Test with single word."""
+        result = get_sentiment_scores(["love"])
+        assert "love" in result
+        category, score = result["love"]
+        assert category == "positive"
+
+    def test_multiple_words(self) -> None:
+        """Test with multiple words."""
+        result = get_sentiment_scores(["love", "hate", "the"])
+        assert len(result) == 3
+        assert "love" in result
+        assert "hate" in result
+        assert "the" in result
+
+    def test_deduplication(self) -> None:
+        """Test that duplicate words are deduplicated."""
+        result = get_sentiment_scores(["love", "love", "love"])
+        assert len(result) == 1
+
+    def test_case_insensitive(self) -> None:
+        """Test that lookup is case-insensitive."""
+        result = get_sentiment_scores(["Love", "LOVE", "love"])
+        assert len(result) == 1
+        assert "love" in result
+
+    def test_result_structure(self) -> None:
+        """Test result dictionary structure."""
+        result = get_sentiment_scores(["happy"])
+        assert "happy" in result
+        value = result["happy"]
+        assert isinstance(value, tuple)
+        assert len(value) == 2
+        category, score = value
+        assert category in ("positive", "negative", "neutral")
+        assert isinstance(score, float)

--- a/tests/test_analyzer/test_slang.py
+++ b/tests/test_analyzer/test_slang.py
@@ -1,0 +1,139 @@
+"""Tests for slang detection module."""
+
+import pytest
+
+from barscan.analyzer.slang import (
+    SLANG_WORDS,
+    detect_slang_words,
+    get_slang_count,
+    is_slang,
+)
+
+
+class TestIsSlang:
+    """Tests for is_slang function."""
+
+    def test_known_slang_word(self) -> None:
+        """Test detection of a known slang word."""
+        assert is_slang("gonna") is True
+        assert is_slang("wanna") is True
+        assert is_slang("lit") is True
+        assert is_slang("dope") is True
+
+    def test_non_slang_word(self) -> None:
+        """Test non-slang word returns False."""
+        assert is_slang("love") is False
+        assert is_slang("music") is False
+        assert is_slang("the") is False
+
+    def test_case_insensitive(self) -> None:
+        """Test case-insensitive detection."""
+        assert is_slang("Gonna") is True
+        assert is_slang("GONNA") is True
+        assert is_slang("gOnNa") is True
+
+    def test_with_additional_slang(self) -> None:
+        """Test with additional slang words."""
+        additional = frozenset({"customslang", "myword"})
+        assert is_slang("customslang", additional) is True
+        assert is_slang("myword", additional) is True
+        # Original slang should still work
+        assert is_slang("gonna", additional) is True
+
+    def test_none_additional_slang(self) -> None:
+        """Test with None as additional slang."""
+        assert is_slang("gonna", None) is True
+
+
+class TestDetectSlangWords:
+    """Tests for detect_slang_words function."""
+
+    def test_empty_list(self) -> None:
+        """Test with empty word list."""
+        result = detect_slang_words([])
+        assert result == {}
+
+    def test_mixed_words(self) -> None:
+        """Test with mix of slang and non-slang words."""
+        words = ["gonna", "love", "lit", "music", "dope"]
+        result = detect_slang_words(words)
+        assert result["gonna"] is True
+        assert result["love"] is False
+        assert result["lit"] is True
+        assert result["music"] is False
+        assert result["dope"] is True
+
+    def test_deduplication(self) -> None:
+        """Test that duplicate words are deduplicated."""
+        words = ["gonna", "gonna", "gonna"]
+        result = detect_slang_words(words)
+        assert len(result) == 1
+        assert result["gonna"] is True
+
+    def test_case_normalization(self) -> None:
+        """Test that words are normalized to lowercase."""
+        words = ["Gonna", "GONNA", "gonna"]
+        result = detect_slang_words(words)
+        assert len(result) == 1
+        assert "gonna" in result
+
+    def test_with_additional_slang(self) -> None:
+        """Test with additional slang words."""
+        additional = frozenset({"customword"})
+        words = ["customword", "gonna", "music"]
+        result = detect_slang_words(words, additional)
+        assert result["customword"] is True
+        assert result["gonna"] is True
+        assert result["music"] is False
+
+
+class TestGetSlangCount:
+    """Tests for get_slang_count function."""
+
+    def test_empty_list(self) -> None:
+        """Test with empty word list."""
+        result = get_slang_count([])
+        assert result == 0
+
+    def test_no_slang(self) -> None:
+        """Test with no slang words."""
+        words = ["love", "music", "peace"]
+        result = get_slang_count(words)
+        assert result == 0
+
+    def test_all_slang(self) -> None:
+        """Test with all slang words."""
+        words = ["gonna", "wanna", "lit"]
+        result = get_slang_count(words)
+        assert result == 3
+
+    def test_mixed_words(self) -> None:
+        """Test with mixed slang and non-slang."""
+        words = ["gonna", "love", "lit", "music"]
+        result = get_slang_count(words)
+        assert result == 2
+
+    def test_counts_duplicates(self) -> None:
+        """Test that duplicate slang words are counted."""
+        words = ["gonna", "gonna", "gonna"]
+        result = get_slang_count(words)
+        assert result == 3
+
+
+class TestSlangWordsConstant:
+    """Tests for SLANG_WORDS constant."""
+
+    def test_is_frozenset(self) -> None:
+        """Test that SLANG_WORDS is a frozenset."""
+        assert isinstance(SLANG_WORDS, frozenset)
+
+    def test_contains_common_slang(self) -> None:
+        """Test that common slang words are included."""
+        common_slang = ["gonna", "wanna", "ain't", "yo", "bruh", "lit", "dope"]
+        for word in common_slang:
+            assert word in SLANG_WORDS
+
+    def test_all_lowercase(self) -> None:
+        """Test that all words are lowercase."""
+        for word in SLANG_WORDS:
+            assert word == word.lower()

--- a/tests/test_analyzer/test_tfidf.py
+++ b/tests/test_analyzer/test_tfidf.py
@@ -1,0 +1,178 @@
+"""Tests for TF-IDF calculation module."""
+
+import math
+from collections import Counter
+
+import pytest
+
+from barscan.analyzer.tfidf import (
+    calculate_corpus_tfidf,
+    calculate_document_frequencies,
+    calculate_idf,
+    calculate_tf,
+    calculate_tfidf_scores,
+)
+
+
+class TestCalculateDocumentFrequencies:
+    """Tests for calculate_document_frequencies function."""
+
+    def test_empty_list(self) -> None:
+        """Test with empty document list."""
+        result = calculate_document_frequencies([])
+        assert result == {}
+
+    def test_single_document(self) -> None:
+        """Test with single document."""
+        docs = [Counter({"love": 3, "hate": 1})]
+        result = calculate_document_frequencies(docs)
+        assert result == {"love": 1, "hate": 1}
+
+    def test_multiple_documents(self) -> None:
+        """Test with multiple documents."""
+        docs = [
+            Counter({"love": 3, "hate": 1}),
+            Counter({"love": 2, "peace": 1}),
+            Counter({"peace": 2, "joy": 1}),
+        ]
+        result = calculate_document_frequencies(docs)
+        assert result["love"] == 2  # appears in 2 docs
+        assert result["hate"] == 1  # appears in 1 doc
+        assert result["peace"] == 2  # appears in 2 docs
+        assert result["joy"] == 1  # appears in 1 doc
+
+    def test_word_in_all_documents(self) -> None:
+        """Test word appearing in all documents."""
+        docs = [
+            Counter({"common": 1}),
+            Counter({"common": 2}),
+            Counter({"common": 3}),
+        ]
+        result = calculate_document_frequencies(docs)
+        assert result["common"] == 3
+
+
+class TestCalculateIdf:
+    """Tests for calculate_idf function."""
+
+    def test_zero_document_frequency(self) -> None:
+        """Test IDF when word appears in no documents."""
+        result = calculate_idf(0, 10)
+        assert result == 0.0
+
+    def test_zero_total_documents(self) -> None:
+        """Test IDF when there are no documents."""
+        result = calculate_idf(5, 0)
+        assert result == 0.0
+
+    def test_word_in_all_documents(self) -> None:
+        """Test IDF when word appears in all documents."""
+        result = calculate_idf(10, 10)
+        assert result == math.log(1)  # = 0
+
+    def test_word_in_one_document(self) -> None:
+        """Test IDF when word appears in one document."""
+        result = calculate_idf(1, 10)
+        assert result == math.log(10)
+
+    def test_idf_is_non_negative(self) -> None:
+        """Test that IDF is always non-negative."""
+        for df in range(1, 11):
+            for n in range(df, 11):
+                result = calculate_idf(df, n)
+                assert result >= 0
+
+
+class TestCalculateTf:
+    """Tests for calculate_tf function."""
+
+    def test_zero_total_words(self) -> None:
+        """Test TF when there are no words."""
+        result = calculate_tf(5, 0)
+        assert result == 0.0
+
+    def test_basic_tf(self) -> None:
+        """Test basic TF calculation."""
+        result = calculate_tf(5, 100)
+        assert result == 0.05
+
+    def test_tf_range(self) -> None:
+        """Test that TF is between 0 and 1."""
+        result = calculate_tf(50, 100)
+        assert 0 <= result <= 1
+
+
+class TestCalculateTfidfScores:
+    """Tests for calculate_tfidf_scores function."""
+
+    def test_empty_word_counts(self) -> None:
+        """Test with empty word counts."""
+        result = calculate_tfidf_scores({}, 100, {"love": 1}, 10)
+        assert result == {}
+
+    def test_basic_calculation(self) -> None:
+        """Test basic TF-IDF calculation."""
+        word_counts = {"love": 10}
+        doc_freqs = {"love": 1}
+        result = calculate_tfidf_scores(word_counts, 100, doc_freqs, 10, normalize=False)
+        assert "love" in result
+
+    def test_normalization(self) -> None:
+        """Test normalized scores are in [0, 1] range."""
+        word_counts = {"love": 10, "hate": 5, "peace": 2}
+        doc_freqs = {"love": 1, "hate": 2, "peace": 5}
+        result = calculate_tfidf_scores(word_counts, 100, doc_freqs, 10, normalize=True)
+
+        for score in result.values():
+            assert 0 <= score <= 1
+
+        # Highest TF-IDF should be normalized to 1.0
+        assert max(result.values()) == 1.0
+
+    def test_missing_doc_frequency(self) -> None:
+        """Test handling of words missing from doc_freqs."""
+        word_counts = {"unknown": 5}
+        doc_freqs = {}
+        result = calculate_tfidf_scores(word_counts, 100, doc_freqs, 10)
+        assert result["unknown"] == 0.0
+
+
+class TestCalculateCorpusTfidf:
+    """Tests for calculate_corpus_tfidf function."""
+
+    def test_empty_corpus(self) -> None:
+        """Test with empty corpus."""
+        result = calculate_corpus_tfidf([], {}, 0)
+        assert result == {}
+
+    def test_single_song(self) -> None:
+        """Test with single song."""
+        word_counts_per_song = [Counter({"love": 5, "hate": 2})]
+        aggregate_counts = {"love": 5, "hate": 2}
+        result = calculate_corpus_tfidf(word_counts_per_song, aggregate_counts, 7)
+        assert "love" in result
+        assert "hate" in result
+
+    def test_multiple_songs(self) -> None:
+        """Test with multiple songs."""
+        word_counts_per_song = [
+            Counter({"love": 5, "music": 3}),
+            Counter({"love": 2, "dance": 4}),
+            Counter({"music": 2, "dance": 1}),
+        ]
+        aggregate_counts = {"love": 7, "music": 5, "dance": 5}
+        result = calculate_corpus_tfidf(word_counts_per_song, aggregate_counts, 17)
+
+        assert "love" in result
+        assert "music" in result
+        assert "dance" in result
+
+    def test_normalization_max_is_one(self) -> None:
+        """Test that maximum normalized score is 1.0."""
+        word_counts_per_song = [
+            Counter({"rare": 10}),  # High TF, appears in one doc
+            Counter({"common": 1}),
+        ]
+        aggregate_counts = {"rare": 10, "common": 1}
+        result = calculate_corpus_tfidf(word_counts_per_song, aggregate_counts, 11)
+        assert max(result.values()) == 1.0


### PR DESCRIPTION
## Summary
- Add TF-IDF scores for word importance across song corpus
- Add POS tagging using NLTK's averaged_perceptron_tagger
- Add sentiment analysis using VADER
- Add slang word detection with curated dictionary
- Add context extraction with copyright-safe modes (none/short/full)

## New CLI Options
- `--enhanced`: Enable TF-IDF, POS, and sentiment analysis
- `--contexts-mode`: Set context extraction mode (none/short/full)
- `--detect-slang`: Enable slang detection

## New Modules
- `analyzer/pos.py`: POS tagging
- `analyzer/sentiment.py`: VADER sentiment analysis
- `analyzer/tfidf.py`: TF-IDF calculation
- `analyzer/slang.py`: Slang detection with 100+ slang words
- `analyzer/context.py`: Context extraction with copyright handling

## Test plan
- [x] Run `pytest tests/` - 310 tests pass
- [x] Run `mypy src/barscan/ --ignore-missing-imports` - No errors
- [x] Run `ruff check src/barscan/` - All checks passed

Closes #18