### PR TITLE
Fix AttributeError accessing Artist.id with lyricsgenius 3.7.5

### DIFF
--- a/src/barscan/genius/client.py
+++ b/src/barscan/genius/client.py
@@ -318,7 +318,7 @@ class GeniusClient:
     def _convert_artist(self, genius_artist: GeniusArtist) -> Artist:
         """Convert lyricsgenius Artist to Pydantic model."""
         return Artist(
-            id=genius_artist.id,
+            id=genius_artist._body["id"],
             name=genius_artist.name,
             url=genius_artist.url,
             image_url=getattr(genius_artist, "image_url", None),
@@ -332,7 +332,7 @@ class GeniusClient:
             artist_id = genius_song.primary_artist.get("id", 0)
 
         return Song(
-            id=genius_song.id,
+            id=genius_song._body["id"],
             title=genius_song.title,
             title_with_featured=getattr(genius_song, "title_with_featured", genius_song.title),
             artist=genius_song.artist,

--- a/tests/test_genius/conftest.py
+++ b/tests/test_genius/conftest.py
@@ -6,11 +6,10 @@ from unittest.mock import MagicMock
 import pytest
 
 
-@pytest.fixture
-def mock_genius_artist():
+def create_mock_genius_artist():
     """Create a mock lyricsgenius Artist."""
     artist = MagicMock()
-    artist.id = 123
+    artist._body = {"id": 123}
     artist.name = "Test Artist"
     artist.url = "https://genius.com/artists/Test-Artist"
     artist.image_url = "https://images.genius.com/test.jpg"
@@ -20,20 +19,29 @@ def mock_genius_artist():
 
 
 @pytest.fixture
-def mock_genius_song():
+def mock_genius_artist():
+    """Create a mock lyricsgenius Artist."""
+    return create_mock_genius_artist()
+
+
+def create_mock_genius_song():
     """Create a mock lyricsgenius Song."""
     song = MagicMock()
-    song.id = 456
+    song._body = {"id": 456}
     song.title = "Test Song"
     song.title_with_featured = "Test Song (ft. Other Artist)"
     song.artist = "Test Artist"
     song.url = "https://genius.com/Test-artist-test-song-lyrics"
     song.lyrics_state = "complete"
     song.header_image_url = "https://images.genius.com/song.jpg"
-
     song.primary_artist = {"id": 123, "name": "Test Artist"}
-
     return song
+
+
+@pytest.fixture
+def mock_genius_song():
+    """Create a mock lyricsgenius Song."""
+    return create_mock_genius_song()
 
 
 @pytest.fixture

--- a/tests/test_genius/test_client.py
+++ b/tests/test_genius/test_client.py
@@ -10,6 +10,8 @@ from barscan.exceptions import ArtistNotFoundError, GeniusAPIError, NoLyricsFoun
 from barscan.genius.client import GeniusClient
 from barscan.genius.models import Song
 
+from .conftest import create_mock_genius_artist, create_mock_genius_song
+
 
 class TestGeniusClientInit:
     def test_requires_access_token(self, mock_settings):
@@ -41,7 +43,8 @@ class TestGeniusClientInit:
 
 class TestSearchArtist:
     @patch("barscan.genius.client.Genius")
-    def test_search_artist_success(self, mock_genius_class, mock_settings, mock_genius_artist):
+    def test_search_artist_success(self, mock_genius_class, mock_settings):
+        mock_genius_artist = create_mock_genius_artist()
         mock_genius = MagicMock()
         mock_genius.search_artist.return_value = mock_genius_artist
         mock_genius_class.return_value = mock_genius
@@ -66,9 +69,9 @@ class TestSearchArtist:
 
 class TestGetArtistSongs:
     @patch("barscan.genius.client.Genius")
-    def test_get_artist_songs_success(
-        self, mock_genius_class, mock_settings, mock_genius_artist, mock_genius_song
-    ):
+    def test_get_artist_songs_success(self, mock_genius_class, mock_settings):
+        mock_genius_artist = create_mock_genius_artist()
+        mock_genius_song = create_mock_genius_song()
         mock_genius_artist.songs = [mock_genius_song]
         mock_genius = MagicMock()
         mock_genius.search_artist.return_value = mock_genius_artist
@@ -187,9 +190,8 @@ class TestGetLyricsWithCache:
 class TestRetryLogic:
     @patch("barscan.genius.client.Genius")
     @patch("barscan.genius.client.time.sleep")
-    def test_retry_on_failure(
-        self, mock_sleep, mock_genius_class, mock_settings, mock_genius_artist
-    ):
+    def test_retry_on_failure(self, mock_sleep, mock_genius_class, mock_settings):
+        mock_genius_artist = create_mock_genius_artist()
         mock_genius = MagicMock()
         mock_genius.search_artist.side_effect = [
             Exception("Network error"),
@@ -229,14 +231,9 @@ class TestRetryLogic:
 
 class TestGetAllLyrics:
     @patch("barscan.genius.client.Genius")
-    def test_get_all_lyrics(
-        self,
-        mock_genius_class,
-        mock_settings,
-        mock_genius_artist,
-        mock_genius_song,
-        sample_lyrics_text,
-    ):
+    def test_get_all_lyrics(self, mock_genius_class, mock_settings, sample_lyrics_text):
+        mock_genius_artist = create_mock_genius_artist()
+        mock_genius_song = create_mock_genius_song()
         mock_genius_artist.songs = [mock_genius_song]
         mock_genius = MagicMock()
         mock_genius.search_artist.return_value = mock_genius_artist
@@ -250,13 +247,9 @@ class TestGetAllLyrics:
         assert result[0].lyrics_text == sample_lyrics_text
 
     @patch("barscan.genius.client.Genius")
-    def test_skips_songs_without_lyrics(
-        self,
-        mock_genius_class,
-        mock_settings,
-        mock_genius_artist,
-        mock_genius_song,
-    ):
+    def test_skips_songs_without_lyrics(self, mock_genius_class, mock_settings):
+        mock_genius_artist = create_mock_genius_artist()
+        mock_genius_song = create_mock_genius_song()
         mock_genius_artist.songs = [mock_genius_song]
         mock_genius = MagicMock()
         mock_genius.search_artist.return_value = mock_genius_artist
@@ -342,10 +335,9 @@ class TestGetLyricsById:
     """Tests for get_lyrics_by_id method."""
 
     @patch("barscan.genius.client.Genius")
-    def test_get_lyrics_by_id_success(
-        self, mock_genius_class, mock_settings, mock_genius_song, sample_lyrics_text
-    ):
+    def test_get_lyrics_by_id_success(self, mock_genius_class, mock_settings, sample_lyrics_text):
         """Test getting lyrics by song ID."""
+        mock_genius_song = create_mock_genius_song()
         mock_genius = MagicMock()
         mock_genius.search_song.return_value = mock_genius_song
         mock_genius.lyrics.return_value = sample_lyrics_text
@@ -448,10 +440,9 @@ class TestExponentialBackoff:
 
     @patch("barscan.genius.client.Genius")
     @patch("barscan.genius.client.time.sleep")
-    def test_exponential_backoff_delays(
-        self, mock_sleep, mock_genius_class, mock_settings, mock_genius_artist
-    ):
+    def test_exponential_backoff_delays(self, mock_sleep, mock_genius_class, mock_settings):
         """Test that retry delays follow exponential pattern."""
+        mock_genius_artist = create_mock_genius_artist()
         mock_genius = MagicMock()
         mock_genius.search_artist.side_effect = [
             Exception("Error 1"),
@@ -480,10 +471,9 @@ class TestClientEdgeCases:
     """Additional edge case tests for GeniusClient."""
 
     @patch("barscan.genius.client.Genius")
-    def test_get_artist_songs_with_empty_songs_list(
-        self, mock_genius_class, mock_settings, mock_genius_artist
-    ):
+    def test_get_artist_songs_with_empty_songs_list(self, mock_genius_class, mock_settings):
         """Test getting artist with empty songs list."""
+        mock_genius_artist = create_mock_genius_artist()
         mock_genius_artist.songs = []
         mock_genius = MagicMock()
         mock_genius.search_artist.return_value = mock_genius_artist
@@ -496,10 +486,9 @@ class TestClientEdgeCases:
         assert result.total_songs_fetched == 0
 
     @patch("barscan.genius.client.Genius")
-    def test_get_artist_songs_with_none_songs(
-        self, mock_genius_class, mock_settings, mock_genius_artist
-    ):
+    def test_get_artist_songs_with_none_songs(self, mock_genius_class, mock_settings):
         """Test getting artist when songs attribute is None."""
+        mock_genius_artist = create_mock_genius_artist()
         mock_genius_artist.songs = None
         mock_genius = MagicMock()
         mock_genius.search_artist.return_value = mock_genius_artist
@@ -519,11 +508,13 @@ class TestClientEdgeCases:
         client = GeniusClient(settings_obj=mock_settings, enable_cache=False)
 
         # Create minimal artist mock without optional attributes
-        artist = MagicMock(spec=["id", "name", "url"])
-        artist.id = 123
+        artist = MagicMock()
+        artist._body = {"id": 123}
         artist.name = "Test Artist"
         artist.url = "https://genius.com/artists/test"
-        # image_url and is_verified attributes don't exist
+        # Remove image_url and is_verified attributes
+        del artist.image_url
+        del artist.is_verified
 
         result = client._convert_artist(artist)
 
@@ -541,11 +532,14 @@ class TestClientEdgeCases:
         client = GeniusClient(settings_obj=mock_settings, enable_cache=False)
 
         # Create song mock without primary_artist having an id
-        song = MagicMock(spec=["id", "title", "artist", "url", "primary_artist"])
-        song.id = 456
+        song = MagicMock()
+        song._body = {"id": 456}
         song.title = "Test Song"
+        song.title_with_featured = "Test Song"
         song.artist = "Artist Name"
         song.url = "https://genius.com/test"
+        song.lyrics_state = "complete"
+        song.header_image_url = None
         song.primary_artist = None  # No primary artist
 
         result = client._convert_song(song)


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'Artist' object has no attribute 'id'` when using lyricsgenius 3.7.5
- Update `_convert_artist` and `_convert_song` methods to access `id` via `_body["id"]` instead of direct attribute access
- Update test fixtures and refactor tests to use helper functions for creating mock objects

## Changes
- `src/barscan/genius/client.py`: Access id via `_body["id"]` for both Artist and Song objects
- `tests/test_genius/conftest.py`: Add `create_mock_genius_artist()` and `create_mock_genius_song()` helper functions, update fixtures to use `_body` for id
- `tests/test_genius/test_client.py`: Refactor tests to use helper functions instead of fixtures for better mock isolation

## Test plan
- [x] All existing tests pass (310 tests)
- [x] Lint check passes (ruff)
- [x] Type check passes (mypy)

Fixes #25