### PR TITLE
Add type-safe mocks and enhance pytest configuration (#28)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,4 +64,11 @@ mypy_path = "src"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=barscan --cov-report=term-missing"
+addopts = [
+    "--cov=barscan",
+    "--cov-report=term-missing",
+    "--tb=short",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+]

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -7,6 +7,8 @@ import pytest
 from typer.testing import CliRunner
 
 from barscan.cli import app
+from barscan.genius.cache import LyricsCache
+from barscan.genius.client import GeniusClient
 
 
 class TestConfigCommand:
@@ -16,7 +18,7 @@ class TestConfigCommand:
         """Test config command displays settings."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 5,
                     "size_bytes": 1024,
@@ -36,7 +38,7 @@ class TestConfigCommand:
         """Test config command masks the API token."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 0,
                     "size_bytes": 0,
@@ -58,7 +60,7 @@ class TestClearCacheCommand:
         """Test clear-cache when cache is already empty."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 0,
                     "size_bytes": 0,
@@ -75,7 +77,7 @@ class TestClearCacheCommand:
         """Test clear-cache with --force flag."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 5,
                     "size_bytes": 1024,
@@ -94,7 +96,7 @@ class TestClearCacheCommand:
         """Test clear-cache with --expired-only flag."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 5,
                     "size_bytes": 1024,
@@ -113,7 +115,7 @@ class TestClearCacheCommand:
         """Test clear-cache --expired-only when no expired entries."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 5,
                     "size_bytes": 1024,
@@ -130,7 +132,7 @@ class TestClearCacheCommand:
         """Test clear-cache cancelled by user."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 5,
                     "size_bytes": 1024,
@@ -165,7 +167,7 @@ class TestAnalyzeCommand:
             with patch("barscan.cli.GeniusClient") as mock_client_class:
                 from barscan.exceptions import ArtistNotFoundError
 
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.side_effect = ArtistNotFoundError("Not found")
                 mock_client_class.return_value = mock_client
 
@@ -180,7 +182,7 @@ class TestAnalyzeCommand:
         """Test analyze with table output format."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -197,7 +199,7 @@ class TestAnalyzeCommand:
         """Test analyze with JSON output format."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -224,7 +226,7 @@ class TestAnalyzeCommand:
         """Test analyze with CSV output format."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -242,7 +244,7 @@ class TestAnalyzeCommand:
 
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -264,7 +266,7 @@ class TestAnalyzeCommand:
 
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = empty_result
                 mock_client_class.return_value = mock_client
 
@@ -285,7 +287,7 @@ class TestAnalyzeCommand:
         """Test analyze with --exclude option."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -303,7 +305,7 @@ class TestAnalyzeCommand:
         """Test analyze with --no-stop-words option."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -320,7 +322,7 @@ class TestAnalyzeCommand:
             with patch("barscan.cli.GeniusClient") as mock_client_class:
                 from barscan.exceptions import GeniusAPIError
 
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.side_effect = GeniusAPIError("API rate limit")
                 mock_client_class.return_value = mock_client
 
@@ -335,7 +337,7 @@ class TestAnalyzeCommand:
             with patch("barscan.cli.GeniusClient") as mock_client_class:
                 from barscan.exceptions import BarScanError
 
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.side_effect = BarScanError("Generic error")
                 mock_client_class.return_value = mock_client
 
@@ -351,7 +353,7 @@ class TestAnalyzeCommand:
             with patch("barscan.cli.GeniusClient") as mock_client_class:
                 from barscan.exceptions import NoLyricsFoundError
 
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.side_effect = NoLyricsFoundError("No lyrics")
                 mock_client_class.return_value = mock_client
@@ -377,7 +379,7 @@ class TestAnalyzeCommand:
 
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = empty_lyrics
                 mock_client_class.return_value = mock_client
@@ -406,7 +408,7 @@ class TestAnalyzeCommand:
         """Test analyze with wordgrain output format."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -426,7 +428,7 @@ class TestAnalyzeCommand:
 
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -449,7 +451,7 @@ class TestAnalyzeCommand:
 
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -498,7 +500,7 @@ class TestAnalyzeCommand:
 
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = artist_with_songs
                 mock_client.get_lyrics.side_effect = get_lyrics_for_song
                 mock_client_class.return_value = mock_client
@@ -514,7 +516,7 @@ class TestAnalyzeCommand:
         """Test analyze with --max-songs option."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client
@@ -536,7 +538,7 @@ class TestClearCacheEdgeCases:
         """Test clear-cache --expired-only cancelled by user."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 5,
                     "size_bytes": 1024,
@@ -566,7 +568,7 @@ class TestConfigCommand:
 
         with patch("barscan.cli.settings", short_token_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 0,
                     "size_bytes": 0,
@@ -591,7 +593,7 @@ class TestConfigCommand:
 
         with patch("barscan.cli.settings", no_token_settings):
             with patch("barscan.cli.LyricsCache") as mock_cache_class:
-                mock_cache = MagicMock()
+                mock_cache = MagicMock(spec=LyricsCache)
                 mock_cache.get_stats.return_value = {
                     "total_entries": 0,
                     "size_bytes": 0,
@@ -640,7 +642,7 @@ class TestValidation:
         """Test that artist name whitespace is stripped."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
-                mock_client = MagicMock()
+                mock_client = MagicMock(spec=GeniusClient)
                 mock_client.get_artist_songs.return_value = mock_artist_with_songs
                 mock_client.get_lyrics.return_value = mock_lyrics
                 mock_client_class.return_value = mock_client

--- a/tests/test_genius/conftest.py
+++ b/tests/test_genius/conftest.py
@@ -3,12 +3,14 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from lyricsgenius.types import Artist as LyricsGeniusArtist
+from lyricsgenius.types import Song as LyricsGeniusSong
 import pytest
 
 
 def create_mock_genius_artist():
     """Create a mock lyricsgenius Artist."""
-    artist = MagicMock()
+    artist = MagicMock(spec=LyricsGeniusArtist)
     artist._body = {"id": 123}
     artist.name = "Test Artist"
     artist.url = "https://genius.com/artists/Test-Artist"
@@ -26,7 +28,7 @@ def mock_genius_artist():
 
 def create_mock_genius_song():
     """Create a mock lyricsgenius Song."""
-    song = MagicMock()
+    song = MagicMock(spec=LyricsGeniusSong)
     song._body = {"id": 456}
     song.title = "Test Song"
     song.title_with_featured = "Test Song (ft. Other Artist)"

--- a/tests/test_genius/test_client.py
+++ b/tests/test_genius/test_client.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests.exceptions
-
+from lyricsgenius import Genius
+from lyricsgenius.types import Artist as LyricsGeniusArtist
+from lyricsgenius.types import Song as LyricsGeniusSong
 from pydantic import SecretStr
 
 from barscan.exceptions import ArtistNotFoundError, GeniusAPIError, NoLyricsFoundError
@@ -46,7 +48,7 @@ class TestSearchArtist:
     @patch("barscan.genius.client.Genius")
     def test_search_artist_success(self, mock_genius_class, mock_settings):
         mock_genius_artist = create_mock_genius_artist()
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.return_value = mock_genius_artist
         mock_genius_class.return_value = mock_genius
 
@@ -58,7 +60,7 @@ class TestSearchArtist:
 
     @patch("barscan.genius.client.Genius")
     def test_search_artist_not_found(self, mock_genius_class, mock_settings):
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.return_value = None
         mock_genius_class.return_value = mock_genius
 
@@ -74,7 +76,7 @@ class TestGetArtistSongs:
         mock_genius_artist = create_mock_genius_artist()
         mock_genius_song = create_mock_genius_song()
         mock_genius_artist.songs = [mock_genius_song]
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.return_value = mock_genius_artist
         mock_genius_class.return_value = mock_genius
 
@@ -87,7 +89,7 @@ class TestGetArtistSongs:
 
     @patch("barscan.genius.client.Genius")
     def test_get_artist_songs_not_found(self, mock_genius_class, mock_settings):
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.return_value = None
         mock_genius_class.return_value = mock_genius
 
@@ -100,7 +102,7 @@ class TestGetArtistSongs:
 class TestGetLyrics:
     @patch("barscan.genius.client.Genius")
     def test_get_lyrics_success(self, mock_genius_class, mock_settings, sample_lyrics_text):
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.lyrics.return_value = sample_lyrics_text
         mock_genius_class.return_value = mock_genius
 
@@ -120,7 +122,7 @@ class TestGetLyrics:
 
     @patch("barscan.genius.client.Genius")
     def test_get_lyrics_not_found(self, mock_genius_class, mock_settings):
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.lyrics.return_value = None
         mock_genius_class.return_value = mock_genius
 
@@ -140,7 +142,7 @@ class TestGetLyrics:
 
     @patch("barscan.genius.client.Genius")
     def test_get_lyrics_empty(self, mock_genius_class, mock_settings):
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.lyrics.return_value = "   "
         mock_genius_class.return_value = mock_genius
 
@@ -162,7 +164,7 @@ class TestGetLyrics:
 class TestGetLyricsWithCache:
     @patch("barscan.genius.client.Genius")
     def test_returns_cached_lyrics(self, mock_genius_class, mock_settings, sample_lyrics_text):
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.lyrics.return_value = sample_lyrics_text
         mock_genius_class.return_value = mock_genius
 
@@ -193,7 +195,7 @@ class TestRetryLogic:
     @patch("barscan.genius.client.time.sleep")
     def test_retry_on_failure(self, mock_sleep, mock_genius_class, mock_settings):
         mock_genius_artist = create_mock_genius_artist()
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.side_effect = [
             requests.exceptions.ConnectionError("Network error"),
             requests.exceptions.Timeout("Timeout"),
@@ -215,7 +217,7 @@ class TestRetryLogic:
     @patch("barscan.genius.client.Genius")
     @patch("barscan.genius.client.time.sleep")
     def test_raises_after_max_retries(self, mock_sleep, mock_genius_class, mock_settings):
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.side_effect = requests.exceptions.ConnectionError(
             "Persistent error"
         )
@@ -238,7 +240,7 @@ class TestGetAllLyrics:
         mock_genius_artist = create_mock_genius_artist()
         mock_genius_song = create_mock_genius_song()
         mock_genius_artist.songs = [mock_genius_song]
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.return_value = mock_genius_artist
         mock_genius.lyrics.return_value = sample_lyrics_text
         mock_genius_class.return_value = mock_genius
@@ -254,7 +256,7 @@ class TestGetAllLyrics:
         mock_genius_artist = create_mock_genius_artist()
         mock_genius_song = create_mock_genius_song()
         mock_genius_artist.songs = [mock_genius_song]
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.return_value = mock_genius_artist
         mock_genius.lyrics.return_value = None
         mock_genius_class.return_value = mock_genius
@@ -271,7 +273,7 @@ class TestGetSongsPaginated:
     @patch("barscan.genius.client.Genius")
     def test_get_songs_paginated_success(self, mock_genius_class, mock_settings):
         """Test getting paginated songs."""
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.artist_songs.return_value = {
             "songs": [
                 {
@@ -301,7 +303,7 @@ class TestGetSongsPaginated:
     @patch("barscan.genius.client.Genius")
     def test_get_songs_paginated_last_page(self, mock_genius_class, mock_settings):
         """Test getting last page of songs."""
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.artist_songs.return_value = {
             "songs": [
                 {
@@ -323,7 +325,7 @@ class TestGetSongsPaginated:
     @patch("barscan.genius.client.Genius")
     def test_get_songs_paginated_empty(self, mock_genius_class, mock_settings):
         """Test getting empty page of songs."""
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.artist_songs.return_value = None
         mock_genius_class.return_value = mock_genius
 
@@ -341,7 +343,7 @@ class TestGetLyricsById:
     def test_get_lyrics_by_id_success(self, mock_genius_class, mock_settings, sample_lyrics_text):
         """Test getting lyrics by song ID."""
         mock_genius_song = create_mock_genius_song()
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_song.return_value = mock_genius_song
         mock_genius.lyrics.return_value = sample_lyrics_text
         mock_genius_class.return_value = mock_genius
@@ -354,7 +356,7 @@ class TestGetLyricsById:
     @patch("barscan.genius.client.Genius")
     def test_get_lyrics_by_id_not_found(self, mock_genius_class, mock_settings):
         """Test getting lyrics by ID when song not found."""
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_song.return_value = None
         mock_genius_class.return_value = mock_genius
 
@@ -368,7 +370,7 @@ class TestGetLyricsById:
         self, mock_genius_class, mock_settings, sample_lyrics_text
     ):
         """Test that get_lyrics_by_id uses cache."""
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius_class.return_value = mock_genius
 
         client = GeniusClient(settings_obj=mock_settings, enable_cache=True)
@@ -397,7 +399,7 @@ class TestConvertSongFromDict:
     @patch("barscan.genius.client.Genius")
     def test_convert_song_from_dict_full(self, mock_genius_class, mock_settings):
         """Test converting full song dict to Song model."""
-        mock_genius_class.return_value = MagicMock()
+        mock_genius_class.return_value = MagicMock(spec=Genius)
         client = GeniusClient(settings_obj=mock_settings, enable_cache=False)
 
         song_dict = {
@@ -421,7 +423,7 @@ class TestConvertSongFromDict:
     @patch("barscan.genius.client.Genius")
     def test_convert_song_from_dict_minimal(self, mock_genius_class, mock_settings):
         """Test converting minimal song dict to Song model."""
-        mock_genius_class.return_value = MagicMock()
+        mock_genius_class.return_value = MagicMock(spec=Genius)
         client = GeniusClient(settings_obj=mock_settings, enable_cache=False)
 
         song_dict = {
@@ -446,7 +448,7 @@ class TestExponentialBackoff:
     def test_exponential_backoff_delays(self, mock_sleep, mock_genius_class, mock_settings):
         """Test that retry delays follow exponential pattern."""
         mock_genius_artist = create_mock_genius_artist()
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.side_effect = [
             requests.exceptions.ConnectionError("Error 1"),
             requests.exceptions.Timeout("Error 2"),
@@ -478,7 +480,7 @@ class TestClientEdgeCases:
         """Test getting artist with empty songs list."""
         mock_genius_artist = create_mock_genius_artist()
         mock_genius_artist.songs = []
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.return_value = mock_genius_artist
         mock_genius_class.return_value = mock_genius
 
@@ -493,7 +495,7 @@ class TestClientEdgeCases:
         """Test getting artist when songs attribute is None."""
         mock_genius_artist = create_mock_genius_artist()
         mock_genius_artist.songs = None
-        mock_genius = MagicMock()
+        mock_genius = MagicMock(spec=Genius)
         mock_genius.search_artist.return_value = mock_genius_artist
         mock_genius_class.return_value = mock_genius
 
@@ -507,11 +509,11 @@ class TestClientEdgeCases:
         self, mock_genius_class, mock_settings
     ):
         """Test converting artist with missing optional fields."""
-        mock_genius_class.return_value = MagicMock()
+        mock_genius_class.return_value = MagicMock(spec=Genius)
         client = GeniusClient(settings_obj=mock_settings, enable_cache=False)
 
         # Create minimal artist mock without optional attributes
-        artist = MagicMock()
+        artist = MagicMock(spec=LyricsGeniusArtist)
         artist._body = {"id": 123}
         artist.name = "Test Artist"
         artist.url = "https://genius.com/artists/test"
@@ -531,11 +533,11 @@ class TestClientEdgeCases:
         self, mock_genius_class, mock_settings
     ):
         """Test converting song when primary_artist is missing."""
-        mock_genius_class.return_value = MagicMock()
+        mock_genius_class.return_value = MagicMock(spec=Genius)
         client = GeniusClient(settings_obj=mock_settings, enable_cache=False)
 
         # Create song mock without primary_artist having an id
-        song = MagicMock()
+        song = MagicMock(spec=LyricsGeniusSong)
         song._body = {"id": 456}
         song.title = "Test Song"
         song.title_with_featured = "Test Song"


### PR DESCRIPTION
## Summary

Improve test quality by adding `spec=` parameter to MagicMock instances and enhancing pytest configuration.

## Changes

- **pyproject.toml**: Enhanced pytest configuration with `--tb=short` and deprecation warning filters
- **tests/test_genius/conftest.py**: Added `spec=LyricsGeniusArtist` and `spec=LyricsGeniusSong` to mock helpers
- **tests/test_genius/test_client.py**: Added `spec=Genius` to all mock instances (27 locations)
- **tests/test_cli/test_commands.py**: Added `spec=GeniusClient` and `spec=LyricsCache` to mocks (28 locations)

## Benefits

- Catches non-existent method calls during tests
- Early detection of API mismatches during refactoring
- Improved mock reliability

Resolves #28