### PR TITLE
Rename --no-stop-words to --include-stop-words

### DIFF
--- a/src/barscan/cli.py
+++ b/src/barscan/cli.py
@@ -121,11 +121,11 @@ def analyze(
             help="Output file path (default: stdout)",
         ),
     ] = None,
-    no_stop_words: Annotated[
+    include_stop_words: Annotated[
         bool,
         typer.Option(
-            "--no-stop-words",
-            help="Disable stop word filtering",
+            "--include-stop-words",
+            help="Include stop words in output (filtered by default)",
         ),
     ] = False,
     exclude: Annotated[
@@ -195,7 +195,7 @@ def analyze(
     # Build analysis config
     custom_stop_words = frozenset(exclude) if exclude else frozenset()
     config = AnalysisConfig(
-        remove_stop_words=not no_stop_words,
+        remove_stop_words=not include_stop_words,
         custom_stop_words=custom_stop_words,
         compute_tfidf=enhanced,
         compute_pos=enhanced,

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -297,10 +297,10 @@ class TestAnalyzeCommand:
 
                 assert result.exit_code == 0
 
-    def test_analyze_no_stop_words(
+    def test_analyze_include_stop_words(
         self, cli_runner: CliRunner, mock_settings, mock_artist_with_songs, mock_lyrics
     ):
-        """Test analyze with --no-stop-words option."""
+        """Test analyze with --include-stop-words option."""
         with patch("barscan.cli.settings", mock_settings):
             with patch("barscan.cli.GeniusClient") as mock_client_class:
                 mock_client = MagicMock()
@@ -309,7 +309,7 @@ class TestAnalyzeCommand:
                 mock_client_class.return_value = mock_client
 
                 result = cli_runner.invoke(
-                    app, ["analyze", "Test Artist", "--no-stop-words", "-t", "5"]
+                    app, ["analyze", "Test Artist", "--include-stop-words", "-t", "5"]
                 )
 
                 assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- Rename misleading `--no-stop-words` flag to `--include-stop-words`
- Update help text to clarify behavior: "Include stop words in output (filtered by default)"
- Update corresponding test

Fixes #30