### PR TITLE
Add --min-count option to filter low-frequency words

### DIFF
--- a/src/barscan/analyzer/frequency.py
+++ b/src/barscan/analyzer/frequency.py
@@ -33,12 +33,15 @@ def count_frequencies(tokens: list[str]) -> Counter[str]:
     return Counter(tokens)
 
 
-def create_word_frequencies(counter: Counter[str], total_words: int) -> tuple[WordFrequency, ...]:
+def create_word_frequencies(
+    counter: Counter[str], total_words: int, min_count: int = 1
+) -> tuple[WordFrequency, ...]:
     """Convert Counter to sorted tuple of WordFrequency objects.
 
     Args:
         counter: Counter with word frequencies.
         total_words: Total word count for percentage calculation.
+        min_count: Minimum occurrence count to include (default: 1).
 
     Returns:
         Tuple of WordFrequency objects sorted by count descending.
@@ -53,6 +56,7 @@ def create_word_frequencies(counter: Counter[str], total_words: int) -> tuple[Wo
             percentage=round((count / total_words) * 100, 2),
         )
         for word, count in counter.most_common()
+        if count >= min_count
     )
 
     return frequencies
@@ -153,16 +157,21 @@ def analyze_lyrics(
 def aggregate_results(
     results: list[AnalysisResult],
     artist_name: str,
+    config: AnalysisConfig | None = None,
 ) -> AggregateAnalysisResult:
     """Aggregate multiple song analysis results into one.
 
     Args:
         results: List of individual song analysis results.
         artist_name: Name of the artist.
+        config: Analysis configuration for min_count filtering (uses default if None).
 
     Returns:
         AggregateAnalysisResult with combined frequencies.
     """
+    if config is None:
+        config = AnalysisConfig()
+
     if not results:
         return AggregateAnalysisResult(
             artist_name=artist_name,
@@ -182,7 +191,7 @@ def aggregate_results(
 
     total_words = sum(combined_counter.values())
     unique_words = len(combined_counter)
-    frequencies = create_word_frequencies(combined_counter, total_words)
+    frequencies = create_word_frequencies(combined_counter, total_words, config.min_count)
 
     return AggregateAnalysisResult(
         artist_name=artist_name,

--- a/src/barscan/analyzer/models.py
+++ b/src/barscan/analyzer/models.py
@@ -35,6 +35,7 @@ class AnalysisConfig(BaseModel, frozen=True):
 
     Attributes:
         min_word_length: Minimum word length to include.
+        min_count: Minimum occurrence count to include.
         use_lemmatization: Whether to apply lemmatization.
         remove_stop_words: Whether to filter out stop words.
         custom_stop_words: Additional stop words to filter.
@@ -48,6 +49,7 @@ class AnalysisConfig(BaseModel, frozen=True):
     """
 
     min_word_length: int = Field(default=2, ge=1, description="Minimum word length to include")
+    min_count: int = Field(default=1, ge=1, description="Minimum occurrence count to include")
     use_lemmatization: bool = Field(default=False, description="Whether to apply lemmatization")
     remove_stop_words: bool = Field(default=True, description="Whether to filter out stop words")
     custom_stop_words: frozenset[str] = Field(

--- a/src/barscan/cli.py
+++ b/src/barscan/cli.py
@@ -166,6 +166,14 @@ def analyze(
             help="Enable slang word detection for WordGrain output",
         ),
     ] = False,
+    min_count: Annotated[
+        int,
+        typer.Option(
+            "--min-count",
+            help="Minimum occurrence count to include",
+            min=1,
+        ),
+    ] = 1,
 ) -> None:
     """Analyze word frequency in an artist's lyrics."""
     setup_logging(verbose=verbose)
@@ -202,6 +210,7 @@ def analyze(
         compute_sentiment=enhanced,
         detect_slang=detect_slang,
         contexts_mode=contexts_mode_enum,
+        min_count=min_count,
     )
 
     # Track if we need enhanced data
@@ -265,7 +274,7 @@ def analyze(
             raise typer.Exit(0)
 
         # Aggregate results
-        aggregate = aggregate_results(results, artist_data.artist.name)
+        aggregate = aggregate_results(results, artist_data.artist.name, config)
         top_frequencies = aggregate.top_words(top_words)
 
         # Prepare enhanced data if needed


### PR DESCRIPTION
## Summary
- Add `min_count` field to `AnalysisConfig` model
- Apply min_count filtering in `create_word_frequencies()` function
- Add `--min-count` CLI option to `analyze` command
- Add tests for min_count filtering behavior

## Usage
```bash
# Only show words that appear 3 or more times
barscan analyze "Drake" --min-count 3
```

## Test plan
- [x] Run existing tests to ensure no regressions
- [x] Add tests for `create_word_frequencies()` with min_count parameter
- [x] Add tests for `aggregate_results()` with min_count config
- [x] Run mypy type checking
- [x] Run ruff linting

Closes #31