### PR TITLE
Fix WordGrain schema URL from mumbl.dev to GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Output example:
 
 ```json
 {
-  "$schema": "https://mumbl.dev/schemas/wordgrain/v0.1.0",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
   "meta": {
     "source": "genius",
     "artist": "Kendrick Lamar",

--- a/src/barscan/output/wordgrain.py
+++ b/src/barscan/output/wordgrain.py
@@ -4,7 +4,7 @@ This module provides Pydantic models and functions to export analysis results
 in the WordGrain JSON format (.wg.json), a standardized schema for vocabulary
 analysis data.
 
-Reference: https://mumbl.dev/schemas/wordgrain/v0.1.0
+Reference: https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ from barscan.analyzer.sentiment import get_sentiment_scores
 from barscan.analyzer.slang import detect_slang_words
 from barscan.analyzer.tfidf import calculate_corpus_tfidf
 
-WORDGRAIN_SCHEMA_URL = "https://mumbl.dev/schemas/wordgrain/v0.1.0"
+WORDGRAIN_SCHEMA_URL = "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json"
 
 
 class WordGrainGrain(BaseModel, frozen=True):

--- a/tests/test_output/test_wordgrain.py
+++ b/tests/test_output/test_wordgrain.py
@@ -136,7 +136,7 @@ class TestWordGrainDocument:
             ),
             grains=(),
         )
-        assert doc.schema_ == "https://mumbl.dev/schemas/wordgrain/v0.1.0"
+        assert doc.schema_ == "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json"
 
     def test_schema_field_alias(self) -> None:
         """Test that $schema field is serialized correctly."""


### PR DESCRIPTION
## Summary
- Update WordGrain schema URL from `https://mumbl.dev/schemas/wordgrain/v0.1.0` to `https://github.com/shimpeiws/word-grain`

## Changes
| File | Description |
|------|-------------|
| `src/barscan/output/wordgrain.py` | Update docstring reference and `WORDGRAIN_SCHEMA_URL` constant |
| `README.md` | Update output example |
| `tests/test_output/test_wordgrain.py` | Update test assertion |

## Test plan
- [x] Run `pytest tests/test_output/test_wordgrain.py -v` - 40 tests passed
- [x] Run `ruff check src/` - All checks passed
- [x] Verify no remaining `mumbl.dev` references

Closes #36