### PR TITLE
Add explicit lowercase normalization after tokenization

### DIFF
--- a/src/barscan/analyzer/processor.py
+++ b/src/barscan/analyzer/processor.py
@@ -220,6 +220,8 @@ def preprocess(text: str, config: AnalysisConfig | None = None) -> list[str]:
     cleaned = clean_lyrics(text)
     normalized = normalize_text(cleaned, config)
     tokens = tokenize(normalized, config)
+    # Ensure all tokens are lowercase (safety measure for mixed-language text)
+    tokens = [token.lower() for token in tokens]
     tokens = lemmatize(tokens, config, text=cleaned)
 
     return tokens
@@ -314,6 +316,9 @@ def tokenize_with_positions(
                 line_tokens = tokenizer.tokenize(normalized_line)
         except LookupError as e:
             raise NLTKResourceError(f"Tokenization failed: {e}") from e
+
+        # Ensure all tokens are lowercase (safety measure for mixed-language text)
+        line_tokens = [token.lower() for token in line_tokens]
 
         # Optionally lemmatize (only for English)
         if config.use_lemmatization and language == "english":

--- a/tests/test_analyzer/test_processor.py
+++ b/tests/test_analyzer/test_processor.py
@@ -280,6 +280,19 @@ class TestProcessorEdgeCases:
         assert result.count("yeah") == 3 or "yeah" in result
         assert result.count("baby") == 2 or "baby" in result
 
+    def test_preprocess_normalizes_mixed_case_to_lowercase(self) -> None:
+        """Test that mixed-case words are normalized to lowercase."""
+        text = "[Hook]\nYeah YEAH yeah Wavy WAVY"
+        result = preprocess(text)
+        # All variations should become lowercase
+        assert "yeah" in result
+        assert "wavy" in result
+        # No uppercase versions should exist
+        assert "Yeah" not in result
+        assert "YEAH" not in result
+        assert "Wavy" not in result
+        assert "WAVY" not in result
+
     def test_clean_lyrics_multiline_headers(self) -> None:
         """Test cleaning lyrics with headers spanning lines."""
         text = "[Verse 1]\n[By Artist]\nActual lyrics here"


### PR DESCRIPTION
## Summary
- Add explicit `.lower()` call after tokenization in `preprocess()` function
- Add explicit `.lower()` call after tokenization in `tokenize_with_positions()` function
- Add test case to verify mixed-case words are normalized to lowercase

## Root Cause
While `normalize_text()` applies `.lower()`, NLTK's `word_tokenize` may behave unexpectedly with mixed-language text, preserving original case in some tokens.

## Solution
Add safety measure to ensure all tokens are lowercase after tokenization, preventing "Yeah" and "yeah" or "Wavy" and "WAVY" from being counted as different words.

Fixes #39

## Test plan
- [x] Run `ruff check src/` - All checks passed
- [x] Run `mypy src/barscan/ --ignore-missing-imports` - No issues found
- [x] Run `pytest tests/test_analyzer/test_processor.py -v` - 52 tests passed