### PR TITLE
Add PyPI publishing setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/barscan
 
     steps:
       - uses: actions/checkout@v4
@@ -63,3 +67,6 @@ jobs:
             --title "Release ${{ github.ref_name }}" \
             --generate-notes \
             dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 shimpeiws
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ A Python CLI tool that analyzes word frequency in song lyrics using the Genius A
 
 ## Installation
 
+### Prerequisites
+
+- Python 3.11 or higher
+- pip (latest version recommended)
+
 ### From PyPI (when published)
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11"
 authors = [
-    { name = "shimpeiws" }
+    { name = "shimpeiws", email = "shimpeiws@gmail.com" }
 ]
 keywords = ["lyrics", "genius", "word-frequency", "nlp", "cli"]
 classifiers = [
@@ -18,7 +18,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Text Processing :: Linguistic",
 ]
-
 dependencies = [
     "lyricsgenius>=3.0.1",
     "typer[all]>=0.15.0",
@@ -27,6 +26,13 @@ dependencies = [
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/shimpeiws/barscan"
+Repository = "https://github.com/shimpeiws/barscan.git"
+Issues = "https://github.com/shimpeiws/barscan/issues"
+Changelog = "https://github.com/shimpeiws/barscan/releases"
+"WordGrain Schema" = "https://github.com/shimpeiws/word-grain"
 
 [project.optional-dependencies]
 japanese = ["janome>=0.5.0", "stopwordsiso>=0.6.1"]


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file
- Add author email and project URLs to pyproject.toml
- Configure GitHub Actions release workflow for PyPI trusted publisher

## Setup Required
After merging, configure PyPI trusted publisher at https://pypi.org/manage/account/publishing/:
- PyPI Project Name: `barscan`
- Owner: `shimpeiws`
- Repository: `barscan`
- Workflow: `release.yml`
- Environment: `pypi`

## Test plan
- [ ] CI passes
- [ ] After merge, create tag (e.g., `v0.2.2`) and verify PyPI publish