### PR TITLE
Add Japanese sentiment analysis using oseti dictionaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Changelog = "https://github.com/shimpeiws/barscan/releases"
 "WordGrain Schema" = "https://github.com/shimpeiws/word-grain"
 
 [project.optional-dependencies]
-japanese = ["janome>=0.5.0", "stopwordsiso>=0.6.1"]
+japanese = ["janome>=0.5.0", "stopwordsiso>=0.6.1", "oseti>=0.4"]
 dev = [
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",

--- a/src/barscan/analyzer/sentiment.py
+++ b/src/barscan/analyzer/sentiment.py
@@ -1,6 +1,10 @@
-"""Sentiment analysis using NLTK VADER."""
+"""Sentiment analysis using NLTK VADER and oseti dictionaries for Japanese."""
 
 from __future__ import annotations
+
+import json
+from importlib.util import find_spec
+from pathlib import Path
 
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
 
@@ -9,6 +13,9 @@ from barscan.exceptions import NLTKResourceError
 
 # Singleton instance for performance
 _sia: SentimentIntensityAnalyzer | None = None
+
+# Singleton for Japanese sentiment dictionaries
+_ja_dict: dict[str, float] | None = None
 
 
 def ensure_sentiment_resources() -> None:
@@ -39,20 +46,99 @@ def _get_analyzer() -> SentimentIntensityAnalyzer:
     return _sia
 
 
-def analyze_sentiment(text: str) -> tuple[str, float]:
+def _load_japanese_dict() -> dict[str, float]:
+    """Load oseti sentiment dictionaries for Japanese.
+
+    Returns:
+        Dictionary mapping words to polarity scores (+1.0 or -1.0).
+
+    Raises:
+        NLTKResourceError: If oseti is not installed.
+    """
+    global _ja_dict
+    if _ja_dict is not None:
+        return _ja_dict
+
+    spec = find_spec("oseti")
+    if spec is None or spec.origin is None:
+        raise NLTKResourceError(
+            "oseti package is required for Japanese sentiment analysis. "
+            "Install it with: pip install barscan[japanese]",
+            resource_name="oseti",
+        )
+
+    dic_dir = Path(spec.origin).parent / "dic"
+    result: dict[str, float] = {}
+
+    # Load pn_noun.json: "p" → +1.0, "n" → -1.0, others → skip
+    noun_path = dic_dir / "pn_noun.json"
+    if noun_path.exists():
+        with noun_path.open(encoding="utf-8") as f:
+            pn_noun: dict[str, str] = json.load(f)
+        for word, label in pn_noun.items():
+            if label == "p":
+                result[word] = 1.0
+            elif label == "n":
+                result[word] = -1.0
+
+    # Load pn_wago.json: "ポジ" in value → +1.0, "ネガ" in value → -1.0
+    wago_path = dic_dir / "pn_wago.json"
+    if wago_path.exists():
+        with wago_path.open(encoding="utf-8") as f:
+            pn_wago: dict[str, str] = json.load(f)
+        for word, label in pn_wago.items():
+            if "ポジ" in label:
+                result[word] = 1.0
+            elif "ネガ" in label:
+                result[word] = -1.0
+
+    _ja_dict = result
+    return _ja_dict
+
+
+def _analyze_japanese_word(word: str) -> tuple[str, float]:
+    """Analyze sentiment of a Japanese word using oseti dictionaries.
+
+    Args:
+        word: Japanese word to analyze.
+
+    Returns:
+        Tuple of (category, score).
+
+    Raises:
+        NLTKResourceError: If oseti is not installed.
+    """
+    ja_dict = _load_japanese_dict()
+    score = ja_dict.get(word, 0.0)
+
+    if score >= 0.05:
+        category = "positive"
+    elif score <= -0.05:
+        category = "negative"
+    else:
+        category = "neutral"
+
+    return (category, score)
+
+
+def analyze_sentiment(text: str, language: str = "english") -> tuple[str, float]:
     """Analyze sentiment of text.
 
     Args:
         text: Text to analyze (word, phrase, or sentence).
+        language: Language for analysis ("english" or "japanese").
 
     Returns:
         Tuple of (category, compound_score) where:
         - category: 'positive', 'negative', or 'neutral'
-        - compound_score: VADER compound score from -1.0 to 1.0
+        - compound_score: Score from -1.0 to 1.0
 
     Raises:
-        NLTKResourceError: If VADER is not available.
+        NLTKResourceError: If required resources are not available.
     """
+    if language == "japanese":
+        return _analyze_japanese_word(text)
+
     sia = _get_analyzer()
     scores = sia.polarity_scores(text)
     compound = scores["compound"]
@@ -68,7 +154,7 @@ def analyze_sentiment(text: str) -> tuple[str, float]:
     return (category, round(compound, 4))
 
 
-def analyze_word_sentiment(word: str) -> tuple[str, float]:
+def analyze_word_sentiment(word: str, language: str = "english") -> tuple[str, float]:
     """Analyze sentiment of a single word.
 
     Note: Single words often have neutral sentiment as VADER is designed
@@ -76,27 +162,31 @@ def analyze_word_sentiment(word: str) -> tuple[str, float]:
 
     Args:
         word: Word to analyze.
+        language: Language for analysis ("english" or "japanese").
 
     Returns:
         Tuple of (category, compound_score).
 
     Raises:
-        NLTKResourceError: If VADER is not available.
+        NLTKResourceError: If required resources are not available.
     """
-    return analyze_sentiment(word)
+    return analyze_sentiment(word, language=language)
 
 
-def get_sentiment_scores(words: list[str]) -> dict[str, tuple[str, float]]:
+def get_sentiment_scores(
+    words: list[str], language: str = "english"
+) -> dict[str, tuple[str, float]]:
     """Get sentiment scores for a list of words.
 
     Args:
         words: List of words to analyze.
+        language: Language for analysis ("english" or "japanese").
 
     Returns:
         Dictionary mapping words to (category, compound_score) tuples.
 
     Raises:
-        NLTKResourceError: If VADER is not available.
+        NLTKResourceError: If required resources are not available.
     """
     if not words:
         return {}
@@ -105,6 +195,6 @@ def get_sentiment_scores(words: list[str]) -> dict[str, tuple[str, float]]:
     for word in set(words):  # Deduplicate
         word_lower = word.lower()
         if word_lower not in result:
-            result[word_lower] = analyze_word_sentiment(word_lower)
+            result[word_lower] = analyze_word_sentiment(word_lower, language=language)
 
     return result

--- a/src/barscan/output/wordgrain.py
+++ b/src/barscan/output/wordgrain.py
@@ -39,6 +39,8 @@ _LANGUAGE_TO_ISO: dict[str, str] = {
     "japanese": "ja",
 }
 
+_ISO_TO_LANGUAGE: dict[str, str] = {v: k for k, v in _LANGUAGE_TO_ISO.items()}
+
 
 def resolve_wordgrain_language(config_language: str, words: list[str] | None = None) -> str:
     """Resolve AnalysisConfig language to ISO 639-1 code for WordGrain output.
@@ -301,7 +303,8 @@ def to_wordgrain_enhanced(
     # Compute sentiment if enabled
     sentiment_scores: dict[str, tuple[str, float]] = {}
     if config.compute_sentiment:
-        sentiment_scores = get_sentiment_scores(words)
+        sentiment_language = _ISO_TO_LANGUAGE.get(language, "english")
+        sentiment_scores = get_sentiment_scores(words, language=sentiment_language)
 
     # Detect slang if enabled
     slang_flags: dict[str, bool] = {}

--- a/tests/test_analyzer/test_sentiment.py
+++ b/tests/test_analyzer/test_sentiment.py
@@ -1,5 +1,6 @@
 """Tests for sentiment analysis module."""
 
+from importlib.util import find_spec
 from unittest.mock import patch
 
 import pytest
@@ -123,33 +124,42 @@ class TestGetSentimentScores:
         assert isinstance(score, float)
 
 
+_has_oseti = find_spec("oseti") is not None
+_requires_oseti = pytest.mark.skipif(not _has_oseti, reason="oseti not installed")
+
+
 class TestJapaneseSentiment:
     """Tests for Japanese sentiment analysis."""
 
+    @_requires_oseti
     def test_positive_noun(self) -> None:
         """Test Japanese positive noun (愛 = love)."""
         category, score = analyze_sentiment("愛", language="japanese")
         assert category == "positive"
         assert score == 1.0
 
+    @_requires_oseti
     def test_negative_noun(self) -> None:
         """Test Japanese negative noun (害虫 = pest)."""
         category, score = analyze_sentiment("害虫", language="japanese")
         assert category == "negative"
         assert score == -1.0
 
+    @_requires_oseti
     def test_neutral_word(self) -> None:
         """Test Japanese word not in dictionary."""
         category, score = analyze_sentiment("りんご", language="japanese")
         assert category == "neutral"
         assert score == 0.0
 
+    @_requires_oseti
     def test_positive_noun_happiness(self) -> None:
         """Test Japanese positive noun (幸せ = happiness)."""
         category, score = analyze_sentiment("幸せ", language="japanese")
         assert category == "positive"
         assert score == 1.0
 
+    @_requires_oseti
     def test_get_sentiment_scores_japanese(self) -> None:
         """Test batch sentiment scores for Japanese words."""
         result = get_sentiment_scores(["愛", "害虫", "りんご"], language="japanese")
@@ -182,6 +192,7 @@ class TestJapaneseSentiment:
         assert category == "positive"
         assert score > 0
 
+    @_requires_oseti
     def test_load_japanese_dict_singleton(self) -> None:
         """Test that Japanese dictionary is loaded as singleton."""
         dict1 = _load_japanese_dict()

--- a/tests/test_analyzer/test_sentiment.py
+++ b/tests/test_analyzer/test_sentiment.py
@@ -1,12 +1,16 @@
 """Tests for sentiment analysis module."""
 
+from unittest.mock import patch
+
 import pytest
 
 from barscan.analyzer.sentiment import (
+    _load_japanese_dict,
     analyze_sentiment,
     analyze_word_sentiment,
     get_sentiment_scores,
 )
+from barscan.exceptions import NLTKResourceError
 
 
 class TestAnalyzeSentiment:
@@ -117,3 +121,69 @@ class TestGetSentimentScores:
         category, score = value
         assert category in ("positive", "negative", "neutral")
         assert isinstance(score, float)
+
+
+class TestJapaneseSentiment:
+    """Tests for Japanese sentiment analysis."""
+
+    def test_positive_noun(self) -> None:
+        """Test Japanese positive noun (愛 = love)."""
+        category, score = analyze_sentiment("愛", language="japanese")
+        assert category == "positive"
+        assert score == 1.0
+
+    def test_negative_noun(self) -> None:
+        """Test Japanese negative noun (害虫 = pest)."""
+        category, score = analyze_sentiment("害虫", language="japanese")
+        assert category == "negative"
+        assert score == -1.0
+
+    def test_neutral_word(self) -> None:
+        """Test Japanese word not in dictionary."""
+        category, score = analyze_sentiment("りんご", language="japanese")
+        assert category == "neutral"
+        assert score == 0.0
+
+    def test_positive_noun_happiness(self) -> None:
+        """Test Japanese positive noun (幸せ = happiness)."""
+        category, score = analyze_sentiment("幸せ", language="japanese")
+        assert category == "positive"
+        assert score == 1.0
+
+    def test_get_sentiment_scores_japanese(self) -> None:
+        """Test batch sentiment scores for Japanese words."""
+        result = get_sentiment_scores(["愛", "害虫", "りんご"], language="japanese")
+        assert len(result) == 3
+        assert result["愛"][0] == "positive"
+        assert result["害虫"][0] == "negative"
+        assert result["りんご"][0] == "neutral"
+
+    def test_get_sentiment_scores_japanese_empty(self) -> None:
+        """Test empty list for Japanese."""
+        result = get_sentiment_scores([], language="japanese")
+        assert result == {}
+
+    def test_oseti_not_installed(self) -> None:
+        """Test error when oseti is not installed."""
+        import barscan.analyzer.sentiment as mod
+
+        original = mod._ja_dict
+        mod._ja_dict = None
+        try:
+            with patch("barscan.analyzer.sentiment.find_spec", return_value=None):
+                with pytest.raises(NLTKResourceError, match="oseti"):
+                    analyze_sentiment("愛", language="japanese")
+        finally:
+            mod._ja_dict = original
+
+    def test_english_default_unchanged(self) -> None:
+        """Test that default English behavior is not affected."""
+        category, score = analyze_sentiment("love")
+        assert category == "positive"
+        assert score > 0
+
+    def test_load_japanese_dict_singleton(self) -> None:
+        """Test that Japanese dictionary is loaded as singleton."""
+        dict1 = _load_japanese_dict()
+        dict2 = _load_japanese_dict()
+        assert dict1 is dict2


### PR DESCRIPTION
## Summary

- Add `oseti>=0.4` to `[japanese]` optional dependency
- Add language-aware dispatch in `sentiment.py`: Japanese uses oseti's `pn_noun.json`/`pn_wago.json` dictionaries, English uses VADER as before
- Dictionary loading is lazy & singleton via `importlib.util.find_spec` (no direct oseti import needed)
- Pass resolved language from `wordgrain.py` to `get_sentiment_scores()`
- Add 8 Japanese sentiment tests (positive/negative/neutral/batch/error handling/singleton)

## Test plan

- [x] `pytest tests/test_analyzer/test_sentiment.py -v` — 24 tests pass (15 existing + 9 new)
- [x] `pytest` — 420 tests pass
- [x] `ruff check src/` — clean
- [x] `mypy src/barscan/ --ignore-missing-imports` — clean