### PR TITLE
Support WordGrain v0.2.0 schema with version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,18 +213,30 @@ know,65,1.20
 
 [WordGrain](https://github.com/shimpeiws/word-grain) is a standardized JSON schema for vocabulary analysis data. It enables interoperability between different word frequency analysis tools. See the [documentation](https://shimpeiws.github.io/word-grain/) for details.
 
-Output example:
+You can select the schema version with `--wordgrain-schema` (default: `0.2.0`):
+
+```bash
+# Use default v0.2.0 schema
+barscan analyze "Kendrick Lamar" --format wordgrain
+
+# Use v0.1.0 schema (backward compatible)
+barscan analyze "Kendrick Lamar" --format wordgrain --wordgrain-schema 0.1.0
+```
+
+Output example (v0.2.0):
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+  "$schema": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+  "schema_version": "0.2.0",
+  "type": "word",
   "meta": {
     "source": "genius",
     "artist": "Kendrick Lamar",
     "generated_at": "2024-01-15T10:30:00Z",
     "corpus_size": 10,
     "total_words": 5432,
-    "generator": "barscan/0.1.0",
+    "generator": "barscan/0.3.0",
     "language": "en"
   },
   "grains": [

--- a/src/barscan/cli.py
+++ b/src/barscan/cli.py
@@ -36,6 +36,8 @@ from barscan.exceptions import (
 from barscan.genius import GeniusClient, LyricsCache
 from barscan.logging import setup_logging
 from barscan.output import (
+    DEFAULT_WORDGRAIN_SCHEMA_VERSION,
+    WORDGRAIN_SCHEMA_URLS,
     export_wordgrain,
     generate_filename,
     resolve_wordgrain_language,
@@ -183,6 +185,13 @@ def analyze(
             help="Language for tokenization: english, japanese, or auto (default)",
         ),
     ] = "auto",
+    wordgrain_schema: Annotated[
+        str,
+        typer.Option(
+            "--wordgrain-schema",
+            help=f"WordGrain schema version ({', '.join(WORDGRAIN_SCHEMA_URLS)})",
+        ),
+    ] = DEFAULT_WORDGRAIN_SCHEMA_VERSION,
 ) -> None:
     """Analyze word frequency in an artist's lyrics."""
     setup_logging(verbose=verbose)
@@ -208,6 +217,14 @@ def analyze(
             "Valid options: none, short, full"
         )
         raise typer.Exit(1) from None
+
+    # Validate wordgrain schema version
+    if wordgrain_schema not in WORDGRAIN_SCHEMA_URLS:
+        error_console.print(
+            f"[red]Error:[/red] Invalid WordGrain schema version '{wordgrain_schema}'. "
+            f"Valid options: {', '.join(WORDGRAIN_SCHEMA_URLS)}"
+        )
+        raise typer.Exit(1)
 
     # Validate language
     valid_languages = {"english", "japanese", "auto"}
@@ -316,6 +333,7 @@ def analyze(
             config=config if needs_enhanced else None,
             word_counts_per_song=word_counts_per_song,
             tokens_with_positions=tokens_with_positions,
+            schema_version=wordgrain_schema,
         )
 
         if output_file:
@@ -359,6 +377,7 @@ def format_output(
     config: AnalysisConfig | None = None,
     word_counts_per_song: list[Counter[str]] | None = None,
     tokens_with_positions: list[TokenWithPosition] | None = None,
+    schema_version: str = DEFAULT_WORDGRAIN_SCHEMA_VERSION,
 ) -> str:
     """Format analysis results for output."""
     if output_format == OutputFormat.WORDGRAIN:
@@ -380,9 +399,10 @@ def format_output(
                 word_counts_per_song=word_counts_per_song,
                 tokens_with_positions=tokens_with_positions,
                 language=wg_language,
+                schema_version=schema_version,
             )
         else:
-            document = to_wordgrain(aggregate, language=wg_language)
+            document = to_wordgrain(aggregate, language=wg_language, schema_version=schema_version)
         return export_wordgrain(document)
 
     if output_format == OutputFormat.JSON:

--- a/src/barscan/output/__init__.py
+++ b/src/barscan/output/__init__.py
@@ -1,7 +1,9 @@
 """Output formatting module."""
 
 from barscan.output.wordgrain import (
+    DEFAULT_WORDGRAIN_SCHEMA_VERSION,
     WORDGRAIN_SCHEMA_URL,
+    WORDGRAIN_SCHEMA_URLS,
     WordGrainDocument,
     WordGrainGrain,
     WordGrainMeta,
@@ -14,7 +16,9 @@ from barscan.output.wordgrain import (
 )
 
 __all__ = [
+    "DEFAULT_WORDGRAIN_SCHEMA_VERSION",
     "WORDGRAIN_SCHEMA_URL",
+    "WORDGRAIN_SCHEMA_URLS",
     "WordGrainDocument",
     "WordGrainGrain",
     "WordGrainMeta",

--- a/src/barscan/output/wordgrain.py
+++ b/src/barscan/output/wordgrain.py
@@ -4,7 +4,7 @@ This module provides Pydantic models and functions to export analysis results
 in the WordGrain JSON format (.wg.json), a standardized schema for vocabulary
 analysis data.
 
-Reference: https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json
+Reference: https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json
 """
 
 from __future__ import annotations
@@ -31,7 +31,14 @@ from barscan.analyzer.slang import detect_slang_words
 from barscan.analyzer.tfidf import calculate_corpus_tfidf
 from barscan.analyzer.tokenizer import detect_language
 
-WORDGRAIN_SCHEMA_URL = "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json"
+WORDGRAIN_SCHEMA_URLS: dict[str, str] = {
+    "0.1.0": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json",
+    "0.2.0": "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.2.0/wordgrain.schema.json",
+}
+
+DEFAULT_WORDGRAIN_SCHEMA_VERSION = "0.2.0"
+
+WORDGRAIN_SCHEMA_URL = WORDGRAIN_SCHEMA_URLS[DEFAULT_WORDGRAIN_SCHEMA_VERSION]
 
 # Mapping from AnalysisConfig language names to ISO 639-1 codes
 _LANGUAGE_TO_ISO: dict[str, str] = {
@@ -122,6 +129,8 @@ class WordGrainDocument(BaseModel, frozen=True):
 
     Attributes:
         schema_: JSON Schema URL (serialized as $schema).
+        schema_version: Schema version string (v0.2.0+).
+        type_: Document type discriminator (v0.2.0+).
         meta: Document metadata.
         grains: List of word entries.
     """
@@ -130,6 +139,15 @@ class WordGrainDocument(BaseModel, frozen=True):
         default=WORDGRAIN_SCHEMA_URL,
         alias="$schema",
         description="JSON Schema URL",
+    )
+    schema_version: str | None = Field(
+        default=None,
+        description="Schema version (v0.2.0+)",
+    )
+    type_: str | None = Field(
+        default=None,
+        alias="type",
+        description="Document type discriminator (v0.2.0+)",
     )
     meta: WordGrainMeta = Field(..., description="Document metadata")
     grains: tuple[WordGrainGrain, ...] = Field(
@@ -185,9 +203,20 @@ def _get_generator_string() -> str:
     return f"barscan/{ver}"
 
 
+def _version_fields(schema_version: str) -> dict[str, str]:
+    """Return version-specific fields for WordGrainDocument constructor."""
+    schema_url = WORDGRAIN_SCHEMA_URLS.get(schema_version, WORDGRAIN_SCHEMA_URL)
+    fields: dict[str, str] = {"$schema": schema_url}
+    if schema_version >= "0.2.0":
+        fields["schema_version"] = schema_version
+        fields["type"] = "word"
+    return fields
+
+
 def to_wordgrain(
     aggregate: AggregateAnalysisResult,
     language: str = "en",
+    schema_version: str = DEFAULT_WORDGRAIN_SCHEMA_VERSION,
 ) -> WordGrainDocument:
     """Convert analysis results to WordGrain format.
 
@@ -226,6 +255,7 @@ def to_wordgrain(
     )
 
     return WordGrainDocument(
+        **_version_fields(schema_version),
         meta=meta,
         grains=tuple(grains),
     )
@@ -257,6 +287,7 @@ def to_wordgrain_enhanced(
     word_counts_per_song: list[Counter[str]] | None = None,
     tokens_with_positions: list[TokenWithPosition] | None = None,
     language: str | None = None,
+    schema_version: str = DEFAULT_WORDGRAIN_SCHEMA_VERSION,
 ) -> WordGrainDocument:
     """Convert analysis results to WordGrain format with enhanced NLP fields.
 
@@ -374,6 +405,7 @@ def to_wordgrain_enhanced(
     )
 
     return WordGrainDocument(
+        **_version_fields(schema_version),
         meta=meta,
         grains=tuple(grains),
     )

--- a/tests/test_output/test_wordgrain.py
+++ b/tests/test_output/test_wordgrain.py
@@ -10,7 +10,9 @@ from pydantic import ValidationError
 
 from barscan.analyzer.models import AggregateAnalysisResult, AnalysisConfig, WordFrequency
 from barscan.output.wordgrain import (
+    DEFAULT_WORDGRAIN_SCHEMA_VERSION,
     WORDGRAIN_SCHEMA_URL,
+    WORDGRAIN_SCHEMA_URLS,
     WordGrainDocument,
     WordGrainGrain,
     WordGrainMeta,
@@ -126,7 +128,7 @@ class TestWordGrainDocument:
         assert len(doc.grains) == 2
 
     def test_document_default_schema(self) -> None:
-        """Test default schema URL."""
+        """Test default schema URL points to v0.2.0."""
         doc = WordGrainDocument(
             meta=WordGrainMeta(
                 artist="Test",
@@ -137,7 +139,41 @@ class TestWordGrainDocument:
             ),
             grains=(),
         )
-        assert doc.schema_ == "https://raw.githubusercontent.com/shimpeiws/word-grain/main/schema/v0.1.0/wordgrain.schema.json"
+        assert doc.schema_ == WORDGRAIN_SCHEMA_URLS["0.2.0"]
+
+    def test_document_v020_fields(self) -> None:
+        """Test v0.2.0 fields (schema_version, type)."""
+        doc = WordGrainDocument(
+            **{"$schema": WORDGRAIN_SCHEMA_URLS["0.2.0"]},
+            schema_version="0.2.0",
+            **{"type": "word"},
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        assert doc.schema_version == "0.2.0"
+        assert doc.type_ == "word"
+
+    def test_document_v010_no_extra_fields(self) -> None:
+        """Test v0.1.0 document has no schema_version or type."""
+        doc = WordGrainDocument(
+            **{"$schema": WORDGRAIN_SCHEMA_URLS["0.1.0"]},
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        assert doc.schema_version is None
+        assert doc.type_ is None
 
     def test_schema_field_alias(self) -> None:
         """Test that $schema field is serialized correctly."""
@@ -284,6 +320,20 @@ class TestToWordgrain:
         doc = to_wordgrain(sample_aggregate, language="es")
         assert doc.meta.language == "es"
 
+    def test_default_schema_version(self, sample_aggregate: AggregateAnalysisResult) -> None:
+        """Test default schema version is 0.2.0 with schema_version and type fields."""
+        doc = to_wordgrain(sample_aggregate)
+        assert doc.schema_ == WORDGRAIN_SCHEMA_URLS["0.2.0"]
+        assert doc.schema_version == "0.2.0"
+        assert doc.type_ == "word"
+
+    def test_schema_version_010(self, sample_aggregate: AggregateAnalysisResult) -> None:
+        """Test schema version 0.1.0 has no schema_version or type fields."""
+        doc = to_wordgrain(sample_aggregate, schema_version="0.1.0")
+        assert doc.schema_ == WORDGRAIN_SCHEMA_URLS["0.1.0"]
+        assert doc.schema_version is None
+        assert doc.type_ is None
+
     def test_zero_total_words(self) -> None:
         """Test handling of zero total_words."""
         aggregate = AggregateAnalysisResult(
@@ -334,6 +384,44 @@ class TestExportWordgrain:
         data = json.loads(json_str)
         assert "$schema" in data
         assert data["$schema"] == WORDGRAIN_SCHEMA_URL
+
+    def test_export_v020_includes_schema_version_and_type(self) -> None:
+        """Test that v0.2.0 export includes schema_version and type."""
+        doc = WordGrainDocument(
+            **{"$schema": WORDGRAIN_SCHEMA_URLS["0.2.0"]},
+            schema_version="0.2.0",
+            **{"type": "word"},
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        json_str = export_wordgrain(doc)
+        data = json.loads(json_str)
+        assert data["schema_version"] == "0.2.0"
+        assert data["type"] == "word"
+
+    def test_export_v010_excludes_schema_version_and_type(self) -> None:
+        """Test that v0.1.0 export excludes schema_version and type."""
+        doc = WordGrainDocument(
+            **{"$schema": WORDGRAIN_SCHEMA_URLS["0.1.0"]},
+            meta=WordGrainMeta(
+                artist="Test",
+                generated_at=datetime.now(UTC),
+                corpus_size=1,
+                total_words=100,
+                generator="test/0.1.0",
+            ),
+            grains=(),
+        )
+        json_str = export_wordgrain(doc)
+        data = json.loads(json_str)
+        assert "schema_version" not in data
+        assert "type" not in data
 
     def test_export_format_indentation(self) -> None:
         """Test JSON formatting with indentation."""
@@ -579,3 +667,25 @@ class TestToWordgrainEnhanced:
         assert doc.grains[0].frequency_normalized == 500.0
         # 30 / 1000 * 10000 = 300.0
         assert doc.grains[1].frequency_normalized == 300.0
+
+    def test_enhanced_default_schema_version(
+        self, sample_aggregate: AggregateAnalysisResult
+    ) -> None:
+        """Test default schema version is 0.2.0."""
+        config = AnalysisConfig()
+        doc = to_wordgrain_enhanced(aggregate=sample_aggregate, config=config)
+        assert doc.schema_ == WORDGRAIN_SCHEMA_URLS["0.2.0"]
+        assert doc.schema_version == "0.2.0"
+        assert doc.type_ == "word"
+
+    def test_enhanced_schema_version_010(
+        self, sample_aggregate: AggregateAnalysisResult
+    ) -> None:
+        """Test schema version 0.1.0 has no extra fields."""
+        config = AnalysisConfig()
+        doc = to_wordgrain_enhanced(
+            aggregate=sample_aggregate, config=config, schema_version="0.1.0"
+        )
+        assert doc.schema_ == WORDGRAIN_SCHEMA_URLS["0.1.0"]
+        assert doc.schema_version is None
+        assert doc.type_ is None


### PR DESCRIPTION
## Summary
- Add `--wordgrain-schema` CLI option to select WordGrain schema version (`0.1.0` or `0.2.0`, default `0.2.0`)
- v0.2.0 output includes new `schema_version` and `type` fields; v0.1.0 remains backward-compatible
- Add `WORDGRAIN_SCHEMA_URLS`, `DEFAULT_WORDGRAIN_SCHEMA_VERSION` constants and `_version_fields()` helper

## Test plan
- [x] `pytest tests/test_output/test_wordgrain.py -v` — 58 tests pass
- [x] `ruff check` — no issues
- [x] `mypy --ignore-missing-imports` — no issues

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)